### PR TITLE
Edit TestCMockC.c so it will (mostly) run on 16-bit platforms.

### DIFF
--- a/src/cmock.c
+++ b/src/cmock.c
@@ -5,37 +5,8 @@
 ========================================== */
 
 #include "unity.h"
-#include "cmock.h"
 
-//define CMOCK_MEM_DYNAMIC to grab memory as needed with malloc
-//when you do that, CMOCK_MEM_SIZE is used for incremental size instead of total
-#ifdef CMOCK_MEM_STATIC
-#undef CMOCK_MEM_DYNAMIC
-#endif
-
-#ifdef CMOCK_MEM_DYNAMIC
-#include <stdlib.h>
-#endif
-
-//this is used internally during pointer arithmetic. make sure this type is the same size as the target's pointer type
-#ifndef CMOCK_MEM_PTR_AS_INT
-#define CMOCK_MEM_PTR_AS_INT unsigned long
-#endif
-
-//0 for no alignment, 1 for 16-bit, 2 for 32-bit, 3 for 64-bit
-#ifndef CMOCK_MEM_ALIGN
-#define CMOCK_MEM_ALIGN (2)
-#endif
-
-//amount of memory to allow cmock to use in its internal heap
-#ifndef CMOCK_MEM_SIZE
-#define CMOCK_MEM_SIZE (32768)
-#endif
-
-//automatically calculated defs for easier reading
-#define CMOCK_MEM_ALIGN_SIZE  (1u << CMOCK_MEM_ALIGN)
-#define CMOCK_MEM_ALIGN_MASK  (CMOCK_MEM_ALIGN_SIZE - 1)
-#define CMOCK_MEM_INDEX_SIZE  ((sizeof(CMOCK_MEM_INDEX_TYPE) > CMOCK_MEM_ALIGN_SIZE) ? sizeof(CMOCK_MEM_INDEX_TYPE) : CMOCK_MEM_ALIGN_SIZE)
+#include "cmock_internals.h"
 
 //private variables
 #ifdef CMOCK_MEM_DYNAMIC
@@ -47,6 +18,7 @@ static unsigned char          CMock_Guts_Buffer[CMOCK_MEM_SIZE + CMOCK_MEM_ALIGN
 static CMOCK_MEM_INDEX_TYPE   CMock_Guts_BufferSize = CMOCK_MEM_SIZE + CMOCK_MEM_ALIGN_SIZE;
 static CMOCK_MEM_INDEX_TYPE   CMock_Guts_FreePtr;
 #endif
+
 //-------------------------------------------------------
 // CMock_Guts_MemNew
 //-------------------------------------------------------

--- a/src/cmock_internals.h
+++ b/src/cmock_internals.h
@@ -1,0 +1,43 @@
+/* ==========================================
+    CMock Project - Automatic Mock Generation for C
+    Copyright (c) 2007 Mike Karlesky, Mark VanderVoord, Greg Williams
+    [Released under MIT License. Please refer to license.txt for details]
+========================================== */
+
+#ifndef CMOCK_FRAMEWORK_INTERNALS_H
+#define CMOCK_FRAMEWORK_INTERNALS_H
+
+#include "cmock.h"
+
+//define CMOCK_MEM_DYNAMIC to grab memory as needed with malloc
+//when you do that, CMOCK_MEM_SIZE is used for incremental size instead of total
+#ifdef CMOCK_MEM_STATIC
+#undef CMOCK_MEM_DYNAMIC
+#endif
+
+#ifdef CMOCK_MEM_DYNAMIC
+#include <stdlib.h>
+#endif
+
+//this is used internally during pointer arithmetic. make sure this type is the same size as the target's pointer type
+#ifndef CMOCK_MEM_PTR_AS_INT
+#define CMOCK_MEM_PTR_AS_INT unsigned long
+#endif
+
+//0 for no alignment, 1 for 16-bit, 2 for 32-bit, 3 for 64-bit
+#ifndef CMOCK_MEM_ALIGN
+#define CMOCK_MEM_ALIGN (2)
+#endif
+
+//amount of memory to allow cmock to use in its internal heap
+#ifndef CMOCK_MEM_SIZE
+#define CMOCK_MEM_SIZE (32768)
+#endif
+
+//automatically calculated defs for easier reading
+#define CMOCK_MEM_ALIGN_SIZE  (1u << CMOCK_MEM_ALIGN)
+#define CMOCK_MEM_ALIGN_MASK  (CMOCK_MEM_ALIGN_SIZE - 1)
+#define CMOCK_MEM_INDEX_SIZE  (CMOCK_MEM_PTR_AS_INT)((sizeof(CMOCK_MEM_INDEX_TYPE) > CMOCK_MEM_ALIGN_SIZE) ? sizeof(CMOCK_MEM_INDEX_TYPE) : CMOCK_MEM_ALIGN_SIZE)
+
+
+#endif //CMOCK_FRAMEWORK_INTERNALS

--- a/test/c/TestCMockC.c
+++ b/test/c/TestCMockC.c
@@ -5,7 +5,7 @@
 ========================================== */
 
 #include "unity.h"
-#include "cmock.h"
+#include "cmock_internals.h"
 
 #define TEST_MEM_INDEX_SIZE  (sizeof(CMOCK_MEM_INDEX_TYPE))
 
@@ -73,8 +73,8 @@ void test_ThatWeCanClaimAndChainAFewElementsTogether(void)
   *((unsigned int*)CMock_Guts_GetAddressFor(element[0])) = 0;
 
   //verify we're using the right amount of memory
-  TEST_ASSERT_EQUAL(1 * (TEST_MEM_INDEX_SIZE + 4), CMock_Guts_MemBytesUsed());
-  TEST_ASSERT_EQUAL(CMOCK_MEM_SIZE - 1 * (TEST_MEM_INDEX_SIZE + 4), CMock_Guts_MemBytesFree());
+  TEST_ASSERT_EQUAL(1 * (TEST_MEM_INDEX_SIZE + sizeof(unsigned int)), CMock_Guts_MemBytesUsed());
+  TEST_ASSERT_EQUAL(CMOCK_MEM_SIZE - 1 * (TEST_MEM_INDEX_SIZE + sizeof(unsigned int)), CMock_Guts_MemBytesFree());
 
   //second element
   element[1] = CMock_Guts_MemNew(sizeof(unsigned int));
@@ -84,8 +84,8 @@ void test_ThatWeCanClaimAndChainAFewElementsTogether(void)
   *((unsigned int*)CMock_Guts_GetAddressFor(element[1])) = 1;
 
   //verify we're using the right amount of memory
-  TEST_ASSERT_EQUAL(2 * (TEST_MEM_INDEX_SIZE + 4), CMock_Guts_MemBytesUsed());
-  TEST_ASSERT_EQUAL(CMOCK_MEM_SIZE - 2 * (TEST_MEM_INDEX_SIZE + 4), CMock_Guts_MemBytesFree());
+  TEST_ASSERT_EQUAL(2 * (TEST_MEM_INDEX_SIZE + sizeof(unsigned int)), CMock_Guts_MemBytesUsed());
+  TEST_ASSERT_EQUAL(CMOCK_MEM_SIZE - 2 * (TEST_MEM_INDEX_SIZE + sizeof(unsigned int)), CMock_Guts_MemBytesFree());
 
   //third element
   element[2] = CMock_Guts_MemNew(sizeof(unsigned int));
@@ -96,8 +96,8 @@ void test_ThatWeCanClaimAndChainAFewElementsTogether(void)
   *((unsigned int*)CMock_Guts_GetAddressFor(element[2])) = 2;
 
   //verify we're using the right amount of memory
-  TEST_ASSERT_EQUAL(3 * (TEST_MEM_INDEX_SIZE + 4), CMock_Guts_MemBytesUsed());
-  TEST_ASSERT_EQUAL(CMOCK_MEM_SIZE - 3 * (TEST_MEM_INDEX_SIZE + 4), CMock_Guts_MemBytesFree());
+  TEST_ASSERT_EQUAL(3 * (TEST_MEM_INDEX_SIZE + sizeof(unsigned int)), CMock_Guts_MemBytesUsed());
+  TEST_ASSERT_EQUAL(CMOCK_MEM_SIZE - 3 * (TEST_MEM_INDEX_SIZE + sizeof(unsigned int)), CMock_Guts_MemBytesFree());
 
   //fourth element
   element[3] = CMock_Guts_MemNew(sizeof(unsigned int));
@@ -109,8 +109,8 @@ void test_ThatWeCanClaimAndChainAFewElementsTogether(void)
   *((unsigned int*)CMock_Guts_GetAddressFor(element[3])) = 3;
 
   //verify we're using the right amount of memory
-  TEST_ASSERT_EQUAL(4 * (TEST_MEM_INDEX_SIZE + 4), CMock_Guts_MemBytesUsed());
-  TEST_ASSERT_EQUAL(CMOCK_MEM_SIZE - 4 * (TEST_MEM_INDEX_SIZE + 4), CMock_Guts_MemBytesFree());
+  TEST_ASSERT_EQUAL(4 * (TEST_MEM_INDEX_SIZE + sizeof(unsigned int)), CMock_Guts_MemBytesUsed());
+  TEST_ASSERT_EQUAL(CMOCK_MEM_SIZE - 4 * (TEST_MEM_INDEX_SIZE + sizeof(unsigned int)), CMock_Guts_MemBytesFree());
 
   //traverse list
   next = first;
@@ -125,8 +125,8 @@ void test_ThatWeCanClaimAndChainAFewElementsTogether(void)
   TEST_ASSERT_EQUAL_HEX(CMOCK_GUTS_NONE, next);
 
   //verify we're using the right amount of memory
-  TEST_ASSERT_EQUAL(4 * (TEST_MEM_INDEX_SIZE + 4), CMock_Guts_MemBytesUsed());
-  TEST_ASSERT_EQUAL(CMOCK_MEM_SIZE - 4 * (TEST_MEM_INDEX_SIZE + 4), CMock_Guts_MemBytesFree());
+  TEST_ASSERT_EQUAL(4 * (TEST_MEM_INDEX_SIZE + sizeof(unsigned int)), CMock_Guts_MemBytesUsed());
+  TEST_ASSERT_EQUAL(CMOCK_MEM_SIZE - 4 * (TEST_MEM_INDEX_SIZE + sizeof(unsigned int)), CMock_Guts_MemBytesFree());
 
   //Free it all
   CMock_Guts_MemFreeAll();
@@ -142,13 +142,13 @@ void test_ThatCMockStopsReturningMoreDataWhenItRunsOutOfMemory(void)
   CMOCK_MEM_INDEX_TYPE first = CMOCK_GUTS_NONE;
   CMOCK_MEM_INDEX_TYPE next;
 
-  //even though we are asking for one byte, we've told it to align to closest 4 bytes, therefore it will waste a byte each time
-  //so each call will use 8 bytes (4 for the index, 1 for the data, and 3 wasted).
-  //therefore we can safely allocated total/8 times.
-  for (i = 0; i < (CMOCK_MEM_SIZE / 8); i++)
+  //even though we are asking for one byte, we've told it to align to closest CMOCK_MEM_ALIGN_SIZE bytes, therefore it will waste a byte each time
+  //so each call will use (CMOCK_MEM_INDEX_SIZE + CMOCK_MEM_ALIGN_SIZE) bytes (CMOCK_MEM_INDEX_SIZE for the index, 1 for the data, and (CMOCK_MEM_ALIGN_SIZE - 1) wasted).
+  //therefore we can safely allocated total/(CMOCK_MEM_INDEX_SIZE + CMOCK_MEM_ALIGN_SIZE) times.
+  for (i = 0; i < (CMOCK_MEM_SIZE / (CMOCK_MEM_INDEX_SIZE + CMOCK_MEM_ALIGN_SIZE)); i++)
   {
-    TEST_ASSERT_EQUAL(i*8, CMock_Guts_MemBytesUsed());
-    TEST_ASSERT_EQUAL(CMOCK_MEM_SIZE - i*8, CMock_Guts_MemBytesFree());
+    TEST_ASSERT_EQUAL(i*(CMOCK_MEM_INDEX_SIZE + CMOCK_MEM_ALIGN_SIZE), CMock_Guts_MemBytesUsed());
+    TEST_ASSERT_EQUAL(CMOCK_MEM_SIZE - i*(CMOCK_MEM_INDEX_SIZE + CMOCK_MEM_ALIGN_SIZE), CMock_Guts_MemBytesFree());
 
     next = CMock_Guts_MemNew(1);
     TEST_ASSERT_MESSAGE(next != CMOCK_GUTS_NONE, "Should Not Have Returned CMOCK_GUTS_NONE");
@@ -172,14 +172,14 @@ void test_ThatCMockStopsReturningMoreDataWhenItRunsOutOfMemory(void)
 
   //verify we can still walk through the elements allocated
   next = first;
-  for (i = 0; i < (CMOCK_MEM_SIZE / 8); i++)
+  for (i = 0; i < (CMOCK_MEM_SIZE / (CMOCK_MEM_INDEX_SIZE + CMOCK_MEM_ALIGN_SIZE)); i++)
   {
     TEST_ASSERT_MESSAGE(next != CMOCK_GUTS_NONE, "Should Not Have Returned CMOCK_GUTS_NONE");
     next = CMock_Guts_MemNext(next);
   }
 
   //there aren't any after that
-  TEST_ASSERT_EQUAL_HEX(CMOCK_GUTS_NONE, next);
+  TEST_ASSERT_EQUAL_HEX(CMOCK_GUTS_NONE, (_UU32)next);
 }
 
 void test_ThatCMockStopsReturningMoreDataWhenAskForMoreThanItHasLeftEvenIfNotAtExactEnd(void)
@@ -188,12 +188,13 @@ void test_ThatCMockStopsReturningMoreDataWhenAskForMoreThanItHasLeftEvenIfNotAtE
   CMOCK_MEM_INDEX_TYPE first = CMOCK_GUTS_NONE;
   CMOCK_MEM_INDEX_TYPE next;
 
-  //we're asking for 12 bytes each time now (4 for index, 8 for data).
-  //10 requests will give us 120 bytes used, which isn't enough for another 12 bytes if total memory is 128
-  for (i = 0; i < 10; i++)
+  //we're asking for (CMOCK_MEM_INDEX_SIZE + 8) bytes each time now (CMOCK_MEM_INDEX_SIZE for index, 8 for data).
+  //CMOCK_MEM_SIZE/(CMOCK_MEM_INDEX_SIZE + 8) requests will request as much data as possible, while ensuring that there isn't enough
+  //memory for the next request
+  for (i = 0; i < CMOCK_MEM_SIZE/(CMOCK_MEM_INDEX_SIZE + 8); i++)
   {
-    TEST_ASSERT_EQUAL(i*12, CMock_Guts_MemBytesUsed());
-    TEST_ASSERT_EQUAL(CMOCK_MEM_SIZE - i*12, CMock_Guts_MemBytesFree());
+    TEST_ASSERT_EQUAL(i*(CMOCK_MEM_INDEX_SIZE + 8), CMock_Guts_MemBytesUsed());
+    TEST_ASSERT_EQUAL(CMOCK_MEM_SIZE - i*(CMOCK_MEM_INDEX_SIZE + 8), CMock_Guts_MemBytesFree());
 
     next = CMock_Guts_MemNew(8);
     TEST_ASSERT_MESSAGE(next != CMOCK_GUTS_NONE, "Should Not Have Returned CMOCK_GUTS_NONE");
@@ -206,20 +207,20 @@ void test_ThatCMockStopsReturningMoreDataWhenAskForMoreThanItHasLeftEvenIfNotAtE
   }
 
   //verify we're at top of memory
-  TEST_ASSERT_EQUAL(CMOCK_MEM_SIZE - 8, CMock_Guts_MemBytesUsed());
-  TEST_ASSERT_EQUAL(8, CMock_Guts_MemBytesFree());
+  TEST_ASSERT_EQUAL(CMOCK_MEM_SIZE - CMOCK_MEM_SIZE % (CMOCK_MEM_INDEX_SIZE + 8), CMock_Guts_MemBytesUsed());
+  TEST_ASSERT_EQUAL(CMOCK_MEM_SIZE % (CMOCK_MEM_INDEX_SIZE + 8), CMock_Guts_MemBytesFree());
 
   //The very next call will return a NONE, and any after that
   TEST_ASSERT_EQUAL_HEX(CMOCK_GUTS_NONE, CMock_Guts_MemNew(8));
   TEST_ASSERT_EQUAL_HEX(CMOCK_GUTS_NONE, CMock_Guts_MemNew(5));
 
   //verify nothing has changed
-  TEST_ASSERT_EQUAL(CMOCK_MEM_SIZE - 8, CMock_Guts_MemBytesUsed());
-  TEST_ASSERT_EQUAL(8, CMock_Guts_MemBytesFree());
+  TEST_ASSERT_EQUAL(CMOCK_MEM_SIZE - CMOCK_MEM_SIZE % (CMOCK_MEM_INDEX_SIZE + 8), CMock_Guts_MemBytesUsed());
+  TEST_ASSERT_EQUAL(CMOCK_MEM_SIZE % (CMOCK_MEM_INDEX_SIZE + 8), CMock_Guts_MemBytesFree());
 
   //verify we can still walk through the elements allocated
   next = first;
-  for (i = 0; i < 10; i++)
+  for (i = 0; i < CMOCK_MEM_SIZE/(CMOCK_MEM_INDEX_SIZE + 8); i++)
   {
     TEST_ASSERT_MESSAGE(next != CMOCK_GUTS_NONE, "Should Not Have Returned CMOCK_GUTS_NONE");
     TEST_ASSERT_EQUAL(i, *((unsigned int*)CMock_Guts_GetAddressFor(next)));
@@ -232,6 +233,10 @@ void test_ThatCMockStopsReturningMoreDataWhenAskForMoreThanItHasLeftEvenIfNotAtE
 
 void test_ThatWeCanAskForAllSortsOfSizes(void)
 {
+#if CMOCK_MEM_ALIGN != 2
+  TEST_IGNORE_MESSAGE("Test relies on a particular environmental setup, which is not present");
+#else
+
   unsigned int  i;
   CMOCK_MEM_INDEX_TYPE first = CMOCK_GUTS_NONE;
   CMOCK_MEM_INDEX_TYPE next;
@@ -277,6 +282,7 @@ void test_ThatWeCanAskForAllSortsOfSizes(void)
 
   //there aren't any after that
   TEST_ASSERT_EQUAL_HEX(CMOCK_GUTS_NONE, next);
+#endif
 }
 
 void test_MemEndOfChain(void)


### PR DESCRIPTION
This is useful when testing embedded code, and trying to gain
confidence that CMock works correctly, is configured correctly,
etc.

This involved creating cmock_internal.h which holds #defines
used by cmock.c. These are then also used in TestCMockc.c
instead of hard-coded data sizes.
