### PR TITLE
Assert fixes

### DIFF
--- a/lib/cmock_generator_utils.rb
+++ b/lib/cmock_generator_utils.rb
@@ -183,11 +183,15 @@ class CMockGeneratorUtils
         c_type_local = c_type.gsub(/\*$/,'')
         lines << "    UNITY_TEST_ASSERT_EQUAL_MEMORY((void*)(#{pre}#{expected}), (void*)(#{pre}#{arg_name}), sizeof(#{c_type_local}), cmock_line, \"#{unity_msg}\");\n"
       when "UNITY_TEST_ASSERT_EQUAL_MEMORY_ARRAY"
-        lines << "    if (#{pre}#{expected} == NULL)\n"
-        lines << "      { UNITY_TEST_ASSERT_NULL(#{arg_name}, cmock_line, \"Expected NULL. #{unity_msg}\"); }\n"
-        lines << ((depth_name != 1) ? "    else if (#{depth_name} == 0)\n      { UNITY_TEST_ASSERT_EQUAL_PTR(#{pre}#{expected}, #{pre}#{arg_name}, cmock_line, \"#{unity_msg}\"); }\n" : "")
-        lines << "    else\n"
-        lines << "      { UNITY_TEST_ASSERT_EQUAL_MEMORY_ARRAY((void*)(#{pre}#{expected}), (void*)(#{pre}#{arg_name}), sizeof(#{c_type.sub('*','')}), #{depth_name}, cmock_line, \"#{unity_msg}\"); }\n"
+        if (pre == '&')
+          lines << "    UNITY_TEST_ASSERT_EQUAL_MEMORY_ARRAY((void*)(#{pre}#{expected}), (void*)(#{pre}#{arg_name}), sizeof(#{c_type.sub('*','')}), #{depth_name}, cmock_line, \"#{unity_msg}\");\n"
+        else
+          lines << "    if (#{pre}#{expected} == NULL)\n"
+          lines << "      { UNITY_TEST_ASSERT_NULL(#{arg_name}, cmock_line, \"Expected NULL. #{unity_msg}\"); }\n"
+          lines << ((depth_name != 1) ? "    else if (#{depth_name} == 0)\n      { UNITY_TEST_ASSERT_EQUAL_PTR(#{pre}#{expected}, #{pre}#{arg_name}, cmock_line, \"#{unity_msg}\"); }\n" : "")
+          lines << "    else\n"
+          lines << "      { UNITY_TEST_ASSERT_EQUAL_MEMORY_ARRAY((void*)(#{pre}#{expected}), (void*)(#{pre}#{arg_name}), sizeof(#{c_type.sub('*','')}), #{depth_name}, cmock_line, \"#{unity_msg}\"); }\n"
+        end
       when /_ARRAY/
         if (pre == '&')
           lines << "    #{unity_func}(#{pre}#{expected}, #{pre}#{arg_name}, #{depth_name}, cmock_line, \"#{unity_msg}\");\n"

--- a/test/unit/cmock_generator_utils_test.rb
+++ b/test/unit/cmock_generator_utils_test.rb
@@ -277,8 +277,8 @@ class CMockGeneratorUtilsTest < Test::Unit::TestCase
   should 'handle custom types as memory compares when we have no better way to do it with array plugin enabled' do
     function = { :name => 'Pear' }
     arg      = test_arg[:mytype]
-    expected = "  if (!cmock_call_instance->IgnoreArg_MyMyType)\n  {\n    UNITY_TEST_ASSERT_EQUAL_MEMORY((void*)(&cmock_call_instance->Expected_MyMyType), (void*)(&MyMyType), sizeof(MY_TYPE), cmock_line, \"Function 'Pear' called with unexpected value for argument 'MyMyType'.\");\n  }\n"
-    @unity_helper.expect.get_helper('MY_TYPE').returns(['UNITY_TEST_ASSERT_EQUAL_MEMORY','&'])
+    expected = "  if (!cmock_call_instance->IgnoreArg_MyMyType)\n  {\n    UNITY_TEST_ASSERT_EQUAL_MEMORY_ARRAY((void*)(&cmock_call_instance->Expected_MyMyType), (void*)(&MyMyType), sizeof(MY_TYPE), 1, cmock_line, \"Function 'Pear' called with unexpected value for argument 'MyMyType'.\");\n  }\n"
+    @unity_helper.expect.get_helper('MY_TYPE').returns(['UNITY_TEST_ASSERT_EQUAL_MEMORY_ARRAY','&'])
     assert_equal(expected, @cmock_generator_utils_complex.code_verify_an_arg_expectation(function, arg))
   end
   


### PR DESCRIPTION
With :array and :smart_ptr enabled, CMock generates incorrect assertions for parameters of unknown types which are not typedefs for pointer types.

For example, for a function which takes (mytype myval), CMock generates the following code:

```
    if (&cmock_call_instance->Expected_myval == NULL)
      { UNITY_TEST_ASSERT_NULL(myval, cmock_line, "Expected NULL. Function 'usart_init' called with unexpected value for argument 'myval'."); }
    else
      { UNITY_TEST_ASSERT_EQUAL_MEMORY_ARRAY((void*)(&cmock_call_instance->Expected_myval), (void*)(&myval), sizeof(usart_myval), 1, cmock_line, "Function 'usart_init' called with unexpected value for argument 'myval'."); }
```

The first parameter to UNITY_TEST_ASSERT_NULL should be &myval, but it's myval, but there is a missing #{pre} before #{arg_name} in the Ruby code that generates it. In addition, that entire ASSERT_NULL check is superfluous, since the if clause above it will never return TRUE for pointers we create ourselves.

When I went to fix this bug using TDD, I wound up down the rabbit hole. The test that is supposed to be checking this case, 'handle custom types as memory compares when we have no better way to do it with array plugin enabled', is returning the incorrect handler from get_handler. With the :array plugin enabled, CMockUnityHelperParser.get_helper will return UNITY_TEST_ASSERT_EQUAL_MEMORY_ARRAY, but the unity_helper mock was returning UNITY_TEST_ASSERT_EQUAL_MEMORY. I fixed the test, and fixed the failing code by adding an "if (pre == '&')" clause similar to those in other parts of this module.

This fixed my original bug, but didn't require me to change the original failing code, since its failing corner case is no longer activated. I couldn't figure out the right test to add to motivate that fix, so I left it to developers more familiar with CMock's internals.

While I was investigating this issue, I also found that the unit tests for code_verify_an_arg_expectation weren't operating as intended due to the fact that alias modifies classes, not instances. This pull request includes a fix for that problem as well.

There are still some issues with cmock_generator_utils_test.rb. For example, there are no tests that exercise code_verify_an_arg_expectation_with_normal_arrays. This pull request should be a step in the right direction though.
