### PR TITLE
Fixed problem where 'ReturnThruPtr' statements were ignored with the use of 'ExpectAnyArgs'

### DIFF
--- a/lib/cmock_generator_plugin_expect.rb
+++ b/lib/cmock_generator_plugin_expect.rb
@@ -53,6 +53,7 @@ class CMockGeneratorPluginExpect
     function[:args].each do |arg|
       lines << @utils.code_verify_an_arg_expectation(function, arg)
     end
+    lines << "End_Of_Arg_Expectations: ;\n\n"
     lines
   end
   

--- a/lib/cmock_generator_plugin_expect_any_args.rb
+++ b/lib/cmock_generator_plugin_expect_any_args.rb
@@ -41,11 +41,11 @@ class CMockGeneratorPluginExpectAnyArgs
   def mock_implementation(function)
     lines = "  if (cmock_call_instance->IgnoreMode == CMOCK_ARG_NONE)\n  {\n"
     if (function[:return][:void?])
-      lines << "    return;\n  }\n"
+      lines << "    goto End_Of_Arg_Expectations;\n  }\n"
     else
       retval = function[:return].merge( { :name => "cmock_call_instance->ReturnVal"} )
       lines << "  " + @utils.code_assign_argument_quickly("Mock.#{function[:name]}_FinalReturn", retval) unless (retval[:void?])
-      lines << "    return cmock_call_instance->ReturnVal;\n  }\n"
+      lines << "    goto End_Of_Arg_Expectations;\n  }\n"
     end
     lines
   end


### PR DESCRIPTION
There is a problem using `ExpectAnyArgs` in conjunction with `ReturnThruPtr`.

Once `ExpectAnyArgs` is used, any usage of `ReturnThruPtr` is ignored.  This means that something like this won't work (i.e the mocked function implementation will not return data to the argument `outParam`):

```
MyFunc_ExpectAnyArgsAndReturn(0);
MyFunc_ReturnThruPtr_outParam(&testVal);
```

The problem is with the way code is generated.  In the mocked function implementation, we evaluate argument expectations and after we process parameters for which we need to set data.

However, when `ExpectAnyArgs` is used, related code is placed before argument expectation evaluation and it returns immediately, thus skipping the part that sets data to pointers.

In the fix I did, instead of returning immediately, we jump after evaluation of argument expectations.  This allows execution of code that returns data through arguments.
