### PR TITLE
Properly mark the 'const' state of a function's return type.

### DIFF
--- a/lib/cmock_header_parser.rb
+++ b/lib/cmock_header_parser.rb
@@ -223,7 +223,7 @@ class CMockHeaderParser
     decl[:return] = { :type   => rettype,
                       :name   => 'cmock_to_return',
                       :ptr?   => divine_ptr(rettype),
-                      :const? => rettype.split(/\s/).include?('const'),
+                      :const? => decl[:modifier].split(/\s/).include?('const'),
                       :str    => "#{rettype} cmock_to_return",
                       :void?  => (rettype == 'void')
                     }


### PR DESCRIPTION
During parsing, properly mark the 'const' state of a function's return type.
