### PR TITLE
Better way to fix a 'return from incompatible pointer type' compiler warning

### DIFF
--- a/lib/cmock_generator.rb
+++ b/lib/cmock_generator.rb
@@ -183,8 +183,9 @@ class CMockGenerator
       file << "    UNITY_TEST_FAIL(cmock_line, \"Function '#{function[:name]}' called later than expected.\");\n"
       # file << "  UNITY_TEST_ASSERT((cmock_call_instance->CallOrder == ++GlobalVerifyOrder), cmock_line, \"Out of order function calls. Function '#{function[:name]}'\");\n"
     end
+    return_type_cast = function[:return][:const?] ? "(const #{function[:return][:type]})" : ''
     file << @plugins.run(:mock_implementation, function)
-    file << "  return cmock_call_instance->ReturnVal;\n" unless (function[:return][:void?])
+    file << "  return #{return_type_cast}cmock_call_instance->ReturnVal;\n" unless (function[:return][:void?])
     file << "}\n\n"
   end
 


### PR DESCRIPTION
Now apply only to const return types to avoid other side effects (i.e. to avoid creating other warnings  with some compilers)
