### PR TITLE
Adjusted regex for strippables

### DIFF
--- a/lib/cmock_header_parser.rb
+++ b/lib/cmock_header_parser.rb
@@ -83,7 +83,7 @@ class CMockHeaderParser
     source.gsub!(/(\W)(?:register|auto|static|restrict)(\W)/, '\1\2')                      # remove problem keywords
     source.gsub!(/\s*=\s*['"a-zA-Z0-9_\.]+\s*/, '')                                        # remove default value statements from argument lists
     source.gsub!(/^(?:[\w\s]*\W)?typedef\W[^;]*/m, '')                                     # remove typedef statements
-    source.gsub!(/(^|\W+)(?:#{@c_strippables.join('|')})(?=$|\W+)/,'\1') unless @c_strippables.empty? # remove known attributes slated to be stripped
+    source.gsub!(/(^|\W+)(?:#{@c_strippables.join('|')})(?=$|\W+|(?<=\W))/,'\1') unless @c_strippables.empty? # remove known attributes slated to be stripped
 
     #scan for functions which return function pointers, because they are a pain
     source.gsub!(/([\w\s\*]+)\(*\(\s*\*([\w\s\*]+)\s*\(([\w\s\*,]*)\)\)\s*\(([\w\s\*,]*)\)\)*/) do |m|


### PR DESCRIPTION
Usually, characters following the pattern to strip are expected to be non-alphanumeric.  However, alphanumeric characters should be allowed if last character of the pattern to strip is non-alphanumeric.

The problem I got is when we want to strip a MACRO() and this macro is followed by an alphanumeric character.  For example, if we add `IFRPC_ALEN\s*\(+.*?\)+` to 'strippables'

`int MyFunction( IFRPC_ALEN(4) int param)` 

would be correctly stripped, but not

`int MyFunction( IFRPC_ALEN(4)int param)` 

because the macro is followed by an alphanumeric character.
