### PR TITLE
Fixed another 'return from incompatible pointer type' compiler warning

### DIFF
--- a/lib/cmock_generator_plugin_expect_any_args.rb
+++ b/lib/cmock_generator_plugin_expect_any_args.rb
@@ -45,7 +45,8 @@ class CMockGeneratorPluginExpectAnyArgs
     else
       retval = function[:return].merge( { :name => "cmock_call_instance->ReturnVal"} )
       lines << "  " + @utils.code_assign_argument_quickly("Mock.#{function[:name]}_FinalReturn", retval) unless (retval[:void?])
-      lines << "    return cmock_call_instance->ReturnVal;\n  }\n"
+      return_type_cast = function[:return][:const?] ? "(const #{function[:return][:type]})" : ''
+      lines << "    return #{return_type_cast}cmock_call_instance->ReturnVal;\n  }\n"
     end
     lines
   end


### PR DESCRIPTION
Fixed another 'return from incompatible pointer type' compiler warning generated by ExpectAnyArgs plugin.

Fixed the same way as the other case we fixed (commit ca13c8361c0732b46e1f573a597dc5c0f78e7d23).

All unit tests pass on my machine after this change.
