### PR TITLE
Added configuration item to specify how to include the original header file

### DIFF
--- a/lib/cmock_config.rb
+++ b/lib/cmock_config.rb
@@ -31,6 +31,7 @@ class CMockConfig
     :includes_h_post_orig_header => nil,
     :includes_c_pre_header       => nil,
     :includes_c_post_header      => nil,
+    :orig_header_include_fmt     => '"%s"',
   }
 
   def initialize(options=nil)

--- a/lib/cmock_generator.rb
+++ b/lib/cmock_generator.rb
@@ -69,7 +69,7 @@ class CMockGenerator
     file << "#ifndef _#{define_name}_H\n"
     file << "#define _#{define_name}_H\n\n"
     @includes_h_pre_orig_header.each {|inc| file << "#include #{inc}\n"}
-    file << "#include \"#{orig_filename}\"\n"
+    file << "#include " + @config.orig_header_include_fmt % "#{orig_filename}" + "\n"
     @includes_h_post_orig_header.each {|inc| file << "#include #{inc}\n"}
     plugin_includes = @plugins.run(:include_files)
     file << plugin_includes if (!plugin_includes.empty?)

--- a/test/unit/cmock_generator_main_test.rb
+++ b/test/unit/cmock_generator_main_test.rb
@@ -95,6 +95,7 @@ class CMockGeneratorTest < Test::Unit::TestCase
                  "\n"
                ]
 
+    @config.expect.orig_header_include_fmt.returns('"%s"')
     @plugins.expect.run(:include_files).returns("#include \"PluginRequiredHeader.h\"\n")
 
     @cmock_generator.create_mock_header_header(output, "MockPoutPoutFish.h")
@@ -131,6 +132,7 @@ class CMockGeneratorTest < Test::Unit::TestCase
                  "\n"
                ]
 
+    @config.expect.orig_header_include_fmt.returns('"%s"')
     @plugins.expect.run(:include_files).returns("#include \"PluginRequiredHeader.h\"\n")
 
     @cmock_generator2.create_mock_header_header(output, "MockPout-Pout Fish.h")
@@ -153,6 +155,7 @@ class CMockGeneratorTest < Test::Unit::TestCase
                  "\n"
                ]
 
+    @config.expect.orig_header_include_fmt.returns('"%s"')
     @plugins.expect.run(:include_files).returns('')
 
     @cmock_generator.create_mock_header_header(output, "MockPoutPoutFish.h")
@@ -176,6 +179,7 @@ class CMockGeneratorTest < Test::Unit::TestCase
                  "\n"
                ]
 
+    @config.expect.orig_header_include_fmt.returns('"%s"')
     @plugins.expect.run(:include_files).returns("#include \"PluginRequiredHeader.h\"\n")
 
     @cmock_generator.create_mock_header_header(output, "MockPoutPoutFish.h")


### PR DESCRIPTION
This is useful when mocking a header file that is not local.

For example, if the header file to mock is accessible from `<mymodule/myfile.h>`, one could set the include format to `<mymodule/%s>`.

The default format is `"%s"`, which keep the previous behavior.
