### PR TITLE
Offer a more flexible way to include the original header file

### DIFF
--- a/lib/cmock_config.rb
+++ b/lib/cmock_config.rb
@@ -31,7 +31,7 @@ class CMockConfig
     :includes_h_post_orig_header => nil,
     :includes_c_pre_header       => nil,
     :includes_c_post_header      => nil,
-    :orig_header_include_fmt     => '"%s"',
+    :orig_header_include_fmt     => "#include \"%s\"",
   }
 
   def initialize(options=nil)

--- a/lib/cmock_generator.rb
+++ b/lib/cmock_generator.rb
@@ -69,7 +69,7 @@ class CMockGenerator
     file << "#ifndef _#{define_name}_H\n"
     file << "#define _#{define_name}_H\n\n"
     @includes_h_pre_orig_header.each {|inc| file << "#include #{inc}\n"}
-    file << "#include " + @config.orig_header_include_fmt % "#{orig_filename}" + "\n"
+    file << @config.orig_header_include_fmt.gsub(/%s/, "#{orig_filename}") + "\n"
     @includes_h_post_orig_header.each {|inc| file << "#include #{inc}\n"}
     plugin_includes = @plugins.run(:include_files)
     file << plugin_includes if (!plugin_includes.empty?)

--- a/test/unit/cmock_generator_main_test.rb
+++ b/test/unit/cmock_generator_main_test.rb
@@ -103,7 +103,7 @@ class CMockGeneratorTest < Test::Unit::TestCase
       "\n",
     ]
 
-    @config.expect.orig_header_include_fmt.returns('"%s"')
+    @config.expect.orig_header_include_fmt.returns("#include \"%s\"")
     @plugins.expect.run(:include_files).returns("#include \"PluginRequiredHeader.h\"\n")
 
     @cmock_generator.create_mock_header_header(output, "MockPoutPoutFish.h")
@@ -148,7 +148,7 @@ class CMockGeneratorTest < Test::Unit::TestCase
       "\n",
     ]
 
-    @config.expect.orig_header_include_fmt.returns('"%s"')
+    @config.expect.orig_header_include_fmt.returns("#include \"%s\"")
     @plugins.expect.run(:include_files).returns("#include \"PluginRequiredHeader.h\"\n")
 
     @cmock_generator2.create_mock_header_header(output, "MockPout-Pout Fish.h")
@@ -179,7 +179,7 @@ class CMockGeneratorTest < Test::Unit::TestCase
       "\n",
     ]
 
-    @config.expect.orig_header_include_fmt.returns('"%s"')
+    @config.expect.orig_header_include_fmt.returns("#include \"%s\"")
     @plugins.expect.run(:include_files).returns('')
 
     @cmock_generator.create_mock_header_header(output, "MockPoutPoutFish.h")
@@ -211,7 +211,7 @@ class CMockGeneratorTest < Test::Unit::TestCase
       "\n",
     ]
 
-    @config.expect.orig_header_include_fmt.returns('"%s"')
+    @config.expect.orig_header_include_fmt.returns("#include \"%s\"")
     @plugins.expect.run(:include_files).returns("#include \"PluginRequiredHeader.h\"\n")
 
     @cmock_generator.create_mock_header_header(output, "MockPoutPoutFish.h")


### PR DESCRIPTION
Adjusted _orig_header_include_fmt_ configuration item to offer a more flexible way to include the original header file.

This allow generating code like that:

```
#ifdef SOMETHING
#include <dir/orginal_file.h>
#else
#include "original_file.h"
#endif
```
