### PR TITLE
Override IgnoreAndReturn with ExpectAndReturn.

### DIFF
--- a/lib/cmock_generator_plugin_expect.rb
+++ b/lib/cmock_generator_plugin_expect.rb
@@ -65,14 +65,15 @@ class CMockGeneratorPluginExpect
       else
         lines << "void #{func_name}_CMockExpect(UNITY_LINE_TYPE cmock_line, #{function[:args_string]})\n{\n"
       end
+      lines << @utils.code_add_base_expectation(func_name)
     else
       if (function[:args_string] == "void")
         lines << "void #{func_name}_CMockExpectAndReturn(UNITY_LINE_TYPE cmock_line, #{function[:return][:str]})\n{\n"
       else
         lines << "void #{func_name}_CMockExpectAndReturn(UNITY_LINE_TYPE cmock_line, #{function[:args_string]}, #{function[:return][:str]})\n{\n"
       end
+      lines << @utils.code_add_base_expectation(func_name, true, true)
     end
-    lines << @utils.code_add_base_expectation(func_name)
     lines << @utils.code_call_argument_loader(function)
     lines << @utils.code_assign_argument_quickly("cmock_call_instance->ReturnVal", function[:return]) unless (function[:return][:void?])
     lines << "}\n\n"

--- a/lib/cmock_generator_plugin_expect_any_args.rb
+++ b/lib/cmock_generator_plugin_expect_any_args.rb
@@ -55,10 +55,11 @@ class CMockGeneratorPluginExpectAnyArgs
     lines = ""
     if (function[:return][:void?])
       lines << "void #{function[:name]}_CMockExpectAnyArgs(UNITY_LINE_TYPE cmock_line)\n{\n"
+      lines << @utils.code_add_base_expectation(function[:name], true)
     else
       lines << "void #{function[:name]}_CMockExpectAnyArgsAndReturn(UNITY_LINE_TYPE cmock_line, #{function[:return][:str]})\n{\n"
+      lines << @utils.code_add_base_expectation(function[:name], true, true)
     end
-    lines << @utils.code_add_base_expectation(function[:name], true)
     unless (function[:return][:void?])
       lines << "  cmock_call_instance->ReturnVal = cmock_to_return;\n"
     end

--- a/lib/cmock_generator_utils.rb
+++ b/lib/cmock_generator_utils.rb
@@ -34,13 +34,13 @@ class CMockGeneratorUtils
     end
   end
 
-  def code_add_base_expectation(func_name, global_ordering_supported=true, is_expect_and_return=false)
+  def code_add_base_expectation(func_name, global_ordering_supported=true, override_ignore=false)
     
-    indentation = (@ignore and is_expect_and_return) ? '  ' : ''
+    indentation = (@ignore and override_ignore) ? '  ' : ''
     lines =  "  CMOCK_#{func_name}_CALL_INSTANCE* cmock_call_instance;\n"
-    if ((@ignore and is_expect_and_return))
+    if ((@ignore and override_ignore))
       lines << "  if (Mock.#{func_name}_IgnoreBool)\n"
-      lines << "    cmock_call_instance = (CMOCK_#{func_name}_CALL_INSTANCE*)CMock_Guts_GetAddressFor(Mock.#{func_name}_CallInstance);\n"
+      lines << "    cmock_call_instance = (CMOCK_#{func_name}_CALL_INSTANCE*)CMock_Guts_GetAddressFor(CMock_Guts_MemEndOfChain(Mock.#{func_name}_CallInstance));\n"
       lines << "  else\n"
       lines << "  {\n"
     end
@@ -48,7 +48,7 @@ class CMockGeneratorUtils
     lines << "  #{indentation}cmock_call_instance = (CMOCK_#{func_name}_CALL_INSTANCE*)CMock_Guts_GetAddressFor(cmock_guts_index);\n"
     lines << "  #{indentation}UNITY_TEST_ASSERT_NOT_NULL(cmock_call_instance, cmock_line, \"CMock has run out of memory. Please allocate more.\");\n"
     lines << "  #{indentation}Mock.#{func_name}_CallInstance = CMock_Guts_MemChain(Mock.#{func_name}_CallInstance, cmock_guts_index);\n"
-    lines << "  }\n" if (@ignore and is_expect_and_return)
+    lines << "  }\n" if (@ignore and override_ignore)
     lines << "  memset(cmock_call_instance, 0, sizeof(*cmock_call_instance));\n"
     lines << "  Mock.#{func_name}_IgnoreBool = (int)0;\n" if (@ignore)
     lines << "  cmock_call_instance->LineNumber = cmock_line;\n"

--- a/test/system/test_interactions/ignore_and_return.yml
+++ b/test/system/test_interactions/ignore_and_return.yml
@@ -159,4 +159,31 @@
           TEST_ASSERT_EQUAL(110, function(0, 8, 9));
         }
 
+    - :pass: TRUE
+      :should: 'expect call should override ignore call'
+      :code: |
+        test()
+        {
+          bar_Expect(2);
+          foo_IgnoreAndReturn(10);
+          foo_ExpectAndReturn(1, 50);
+          foo_ExpectAndReturn(2, 60);
+          foo_ExpectAndReturn(3, 70);
+          TEST_ASSERT_EQUAL(180, function(1, 2, 3));
+
+          bar_Expect(5);
+          foo_ExpectAndReturn(4, 30);
+          foo_IgnoreAndReturn(80);
+          foo_ExpectAndReturn(5, 10);
+          foo_ExpectAndReturn(6, 20);
+          TEST_ASSERT_EQUAL(60, function(4, 5, 6));
+
+          bar_Expect(8);
+          foo_ExpectAndReturn(7, 70);
+          foo_ExpectAndReturn(8, 20);
+          foo_IgnoreAndReturn(10);
+          foo_ExpectAndReturn(9, 20);
+          TEST_ASSERT_EQUAL(110, function(7, 8, 9));
+        }
+
 ...

--- a/test/unit/cmock_generator_plugin_expect_test.rb
+++ b/test/unit/cmock_generator_plugin_expect_test.rb
@@ -150,7 +150,7 @@ describe CMockGeneratorPluginExpect, "Verify CMockGeneratorPluginExpect Module" 
 
   it "add mock interfaces for functions of style 'int func(void)'" do
     function = {:name => "Orange", :args => [], :args_string => "void", :return => test_return[:int]}
-    @utils.expect :code_add_base_expectation, "mock_retval_0 ", ["Orange"]
+    @utils.expect :code_add_base_expectation, "mock_retval_0 ", ["Orange", true, true]
     @utils.expect :code_call_argument_loader, "mock_retval_1 ", [function]
     @utils.expect :code_assign_argument_quickly, "mock_retval_2", ["cmock_call_instance->ReturnVal", function[:return]]
     expected = ["void Orange_CMockExpectAndReturn(UNITY_LINE_TYPE cmock_line, int cmock_to_return)\n",
@@ -166,7 +166,7 @@ describe CMockGeneratorPluginExpect, "Verify CMockGeneratorPluginExpect Module" 
 
   it "add mock interfaces for functions of style 'int func(char* pescado)'" do
     function = {:name => "Lemon", :args => [{ :type => "char*", :name => "pescado"}], :args_string => "char* pescado", :return => test_return[:int]}
-    @utils.expect :code_add_base_expectation, "mock_retval_0 ", ["Lemon"]
+    @utils.expect :code_add_base_expectation, "mock_retval_0 ", ["Lemon", true, true]
     @utils.expect :code_call_argument_loader, "mock_retval_1 ", [function]
     @utils.expect :code_assign_argument_quickly, "mock_retval_2", ["cmock_call_instance->ReturnVal", function[:return]]
     expected = ["void Lemon_CMockExpectAndReturn(UNITY_LINE_TYPE cmock_line, char* pescado, int cmock_to_return)\n",

--- a/test/unit/cmock_generator_utils_test.rb
+++ b/test/unit/cmock_generator_utils_test.rb
@@ -56,11 +56,12 @@ describe CMockGeneratorUtils, "Verify CMockGeneratorUtils Module" do
 
   it "add code for a base expectation with no plugins" do
     expected =
+      "  CMOCK_Apple_CALL_INSTANCE* cmock_call_instance;\n" +
       "  CMOCK_MEM_INDEX_TYPE cmock_guts_index = CMock_Guts_MemNew(sizeof(CMOCK_Apple_CALL_INSTANCE));\n" +
-      "  CMOCK_Apple_CALL_INSTANCE* cmock_call_instance = (CMOCK_Apple_CALL_INSTANCE*)CMock_Guts_GetAddressFor(cmock_guts_index);\n" +
+      "  cmock_call_instance = (CMOCK_Apple_CALL_INSTANCE*)CMock_Guts_GetAddressFor(cmock_guts_index);\n" +
       "  UNITY_TEST_ASSERT_NOT_NULL(cmock_call_instance, cmock_line, \"CMock has run out of memory. Please allocate more.\");\n" +
-      "  memset(cmock_call_instance, 0, sizeof(*cmock_call_instance));\n" +
       "  Mock.Apple_CallInstance = CMock_Guts_MemChain(Mock.Apple_CallInstance, cmock_guts_index);\n" +
+      "  memset(cmock_call_instance, 0, sizeof(*cmock_call_instance));\n" +
       "  cmock_call_instance->LineNumber = cmock_line;\n"
     output = @cmock_generator_utils_simple.code_add_base_expectation("Apple")
     assert_equal(expected, output)
@@ -68,11 +69,12 @@ describe CMockGeneratorUtils, "Verify CMockGeneratorUtils Module" do
 
   it "add code for a base expectation with all plugins" do
     expected =
+      "  CMOCK_Apple_CALL_INSTANCE* cmock_call_instance;\n" +
       "  CMOCK_MEM_INDEX_TYPE cmock_guts_index = CMock_Guts_MemNew(sizeof(CMOCK_Apple_CALL_INSTANCE));\n" +
-      "  CMOCK_Apple_CALL_INSTANCE* cmock_call_instance = (CMOCK_Apple_CALL_INSTANCE*)CMock_Guts_GetAddressFor(cmock_guts_index);\n" +
+      "  cmock_call_instance = (CMOCK_Apple_CALL_INSTANCE*)CMock_Guts_GetAddressFor(cmock_guts_index);\n" +
       "  UNITY_TEST_ASSERT_NOT_NULL(cmock_call_instance, cmock_line, \"CMock has run out of memory. Please allocate more.\");\n" +
-      "  memset(cmock_call_instance, 0, sizeof(*cmock_call_instance));\n" +
       "  Mock.Apple_CallInstance = CMock_Guts_MemChain(Mock.Apple_CallInstance, cmock_guts_index);\n" +
+      "  memset(cmock_call_instance, 0, sizeof(*cmock_call_instance));\n" +
       "  Mock.Apple_IgnoreBool = (int)0;\n" +
       "  cmock_call_instance->LineNumber = cmock_line;\n" +
       "  cmock_call_instance->CallOrder = ++GlobalExpectCount;\n" +
@@ -81,13 +83,35 @@ describe CMockGeneratorUtils, "Verify CMockGeneratorUtils Module" do
     assert_equal(expected, output)
   end
 
+  it "add code for a base expectation with override ignore flag set and with all plugins" do
+    expected =
+      "  CMOCK_Apple_CALL_INSTANCE* cmock_call_instance;\n" +
+      "  if (Mock.Apple_IgnoreBool)\n" +
+      "    cmock_call_instance = (CMOCK_Apple_CALL_INSTANCE*)CMock_Guts_GetAddressFor(CMock_Guts_MemEndOfChain(Mock.Apple_CallInstance));\n" +
+      "  else\n" +
+      "  {\n" +
+      "    CMOCK_MEM_INDEX_TYPE cmock_guts_index = CMock_Guts_MemNew(sizeof(CMOCK_Apple_CALL_INSTANCE));\n" +
+      "    cmock_call_instance = (CMOCK_Apple_CALL_INSTANCE*)CMock_Guts_GetAddressFor(cmock_guts_index);\n" +
+      "    UNITY_TEST_ASSERT_NOT_NULL(cmock_call_instance, cmock_line, \"CMock has run out of memory. Please allocate more.\");\n" +
+      "    Mock.Apple_CallInstance = CMock_Guts_MemChain(Mock.Apple_CallInstance, cmock_guts_index);\n" +
+      "  }\n" +
+      "  memset(cmock_call_instance, 0, sizeof(*cmock_call_instance));\n" +
+      "  Mock.Apple_IgnoreBool = (int)0;\n" +
+      "  cmock_call_instance->LineNumber = cmock_line;\n" +
+      "  cmock_call_instance->CallOrder = ++GlobalExpectCount;\n" +
+      "  cmock_call_instance->ExceptionToThrow = CEXCEPTION_NONE;\n"
+    output = @cmock_generator_utils_complex.code_add_base_expectation("Apple", true, true)
+    assert_equal(expected, output)
+  end
+
   it "add code for a base expectation with all plugins and ordering not supported" do
     expected =
+      "  CMOCK_Apple_CALL_INSTANCE* cmock_call_instance;\n" +
       "  CMOCK_MEM_INDEX_TYPE cmock_guts_index = CMock_Guts_MemNew(sizeof(CMOCK_Apple_CALL_INSTANCE));\n" +
-      "  CMOCK_Apple_CALL_INSTANCE* cmock_call_instance = (CMOCK_Apple_CALL_INSTANCE*)CMock_Guts_GetAddressFor(cmock_guts_index);\n" +
+      "  cmock_call_instance = (CMOCK_Apple_CALL_INSTANCE*)CMock_Guts_GetAddressFor(cmock_guts_index);\n" +
       "  UNITY_TEST_ASSERT_NOT_NULL(cmock_call_instance, cmock_line, \"CMock has run out of memory. Please allocate more.\");\n" +
-      "  memset(cmock_call_instance, 0, sizeof(*cmock_call_instance));\n" +
       "  Mock.Apple_CallInstance = CMock_Guts_MemChain(Mock.Apple_CallInstance, cmock_guts_index);\n" +
+      "  memset(cmock_call_instance, 0, sizeof(*cmock_call_instance));\n" +
       "  Mock.Apple_IgnoreBool = (int)0;\n" +
       "  cmock_call_instance->LineNumber = cmock_line;\n" +
       "  cmock_call_instance->ExceptionToThrow = CEXCEPTION_NONE;\n"


### PR DESCRIPTION
I want to be able to set a default return value for mocks in the setUp function using IgnoreAndReturn and later in some tests assert on arguments or change the return value using ExpectAndReturn. Basically I want to override the IgnoreAndReturn call, as is possible with the non-return versions Ignore and Expect.

This is probably the same idea as #34 however I believe that commit didn't entirely solve the problem when using ordering as there will exist cmock call instances both for the IgnoreAndReturns and for the ExpectAndReturns. And when the expect verification takes place the mock will find the ignore instance instead of the expect instance, leading to comparing with the wrong CallOrder value.

This patch makes it so that if an ExpectAndReturn (or ExpectAnyArgsAndReturn) call is made when the IgnoreBool value is set, instead of creating a new cmock call instance, it will modify the cmock call instance created for the IgnoreAndReturn.

Some simple system tests have been written ensuring the behavior.
Unit tests have been added and modified for the changes made.

Note that multiple IgnoreAndReturns followed by ExpectAndReturn will after this patch still lead to test failures and will, if needed, have to be fixed in a seperate issue. I wasn't sure of what the intended behavior should be for those cases and thus it wasn't added.