### PR TITLE
Fix for const to allow returnThruPtr to be generated for const pointers with mutable data

### DIFF
--- a/lib/cmock_header_parser.rb
+++ b/lib/cmock_header_parser.rb
@@ -142,7 +142,7 @@ class CMockHeaderParser
       args << { :type   => (arg_type = arg_elements[0..-2].join(' ')),
                 :name   => arg_elements[-1],
                 :ptr?   => divine_ptr(arg_type),
-                :const? => arg_array.include?('const')
+                :const? => divine_const(arg)
               }
     end
     return args
@@ -151,6 +151,12 @@ class CMockHeaderParser
   def divine_ptr(arg_type)
     return false unless arg_type.include? '*'
     return false if arg_type.gsub(/(const|char|\*|\s)+/,'').empty?
+    return true
+  end
+
+  def divine_const(arg)
+    return false if /const[ *]/.match(arg).nil?                           # check for const
+    return false if /\*/.match(arg) and /const[^*]*\*/.match(arg).nil?    # check const comes before * indicating const data
     return true
   end
 

--- a/test/unit/cmock_header_parser_test.rb
+++ b/test/unit/cmock_header_parser_test.rb
@@ -858,7 +858,7 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                           {:type=>"int", :name=>"int_param", :ptr? => false, :const? => false},
                           {:type=>"int", :name=>"integer", :ptr? => false, :const? => false},
                           {:type=>"char", :name=>"character", :ptr? => false, :const? => false},
-                          {:type=>"int*", :name=>"constant", :ptr? => true, :const? => true}
+                          {:type=>"int*", :name=>"constant", :ptr? => true, :const? => false}
                         ],
                  :args_string=>"const unsigned int const_param, int int_param, int integer, char character, int* const constant",
                  :args_call=>"const_param, int_param, integer, character, constant" }]


### PR DESCRIPTION
As per Issue #57.
This patch fixes a bug that prevents the returnThruPtr function from being generated for constant pointers with mutable data. 