### PR TITLE
Remove #if defined tags which span over multiple lines

### DIFF
--- a/lib/cmock_header_parser.rb
+++ b/lib/cmock_header_parser.rb
@@ -69,6 +69,9 @@ class CMockHeaderParser
     # remove assembler pragma sections
     source.gsub!(/^\s*#\s*pragma\s+asm\s+.*?#\s*pragma\s+endasm/m, '')
 
+    # remove if defined over multiple lines
+    source.gsub!(/^\s*#if defined+.*?#endif/m, '')
+
     # remove gcc's __attribute__ tags
     source.gsub!(/__attribute(?:__)?\s*\(\(+.*\)\)+/, '')
 

--- a/test/unit/cmock_header_parser_test.rb
+++ b/test/unit/cmock_header_parser_test.rb
@@ -150,6 +150,18 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
     assert_equal(expected, @parser.import_source(source))
   end
 
+  it "strip out ifdefs over multiple lines" do
+    source =
+      "#if defined(__TEST) \n" +
+      "    we_do_not_want_to_see_this();\n" +
+      "    or_this();\n" +
+      "#endif\n" +
+      "we_want_this"
+
+    expected = ["we_want_this"]
+
+    assert_equal(expected, @parser.import_source(source))
+  end
 
   it "smush lines together that contain continuation characters" do
     source =


### PR DESCRIPTION
I had a problem when trying to parse headers with `if defined` inside, that were not defined during the compilation. The solution,_ which is not really ideal_, was to strip away anything within this tags. This has solved my problem, but I am already thinking if the connection to unity and its compiler defines could be used somehow (hints welcome).

I have added the unit test for my example.