### PR TITLE
cmock handles multiple helper headers

### DIFF
--- a/lib/cmock_config.rb
+++ b/lib/cmock_config.rb
@@ -84,8 +84,11 @@ class CMockConfig
   end
 
   def load_unity_helper
-    return File.new(@options[:unity_helper_path]).read if (@options[:unity_helper_path])
-    return nil
+    return nil unless (@options[:unity_helper_path])
+
+    return @options[:unity_helper_path].inject("") do |unity_helper, filename|
+      unity_helper + "\n" + File.new(filename).read
+    end
   end
 
   def standard_treat_as_map

--- a/lib/cmock_config.rb
+++ b/lib/cmock_config.rb
@@ -58,6 +58,7 @@ class CMockConfig
       end
     end
     options[:unity_helper_path] ||= options[:unity_helper]
+    options[:unity_helper_path] = [options[:unity_helper_path]] if options[:unity_helper_path].is_a? String
     options[:plugins].compact!
     options[:plugins].map! {|p| p.to_sym}
     @options = options


### PR DESCRIPTION
This mirrors my pull request to Ceedling, which makes config[:unity_helper] an array.

I needed the ability to pass multiple unity helper files to cmock which, in its previous state, could only handle a single one. This patch implements that functionality, while retaining backwards compatibility with old config files.

Some background: I have a (somewhat) large project that's subdivided into several different modules. Some of the modules define custom (struct) types, and some of those types don't play well with raw memory comparisons, being unpacked. With that in mind, I wanted to define some helper functions for my unit tests, and for cmock.

However, not all modules are included in every project's configuration. I could still have made a monolithic helper file, with appropriate preprocessor checks for definition of the correct helper functions, but that seems a) ugly and b) difficult to properly maintain.

Thus, this patch.