### PR TITLE
Add config option that allows for weak mocked functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ test/system/generated
 Gemfile.lock
 .rake_t_cache
 .DS_Store
+*.swp
 examples/make_example/build

--- a/docs/CMock_Summary.md
+++ b/docs/CMock_Summary.md
@@ -287,8 +287,9 @@ Defined in the yaml file, they look more like this:
 * `:mock_suffix`:
   The suffix to append to your mock files. Defaults to “”.
 
-* `:weak_mocks`:
-  When set to true, the generated mocks are defined as weak symbols. Defaults to false.
+* `:weak`:
+  When set to some value, the generated mocks are defined as weak symbols using the configured format. Defaults to ''.
+  Set to '__attribute ((weak))' for weak mocks when using GCC. Set to any non-empty string for weak mocks when using IAR.
 
 * `:subdir`:
   Relative subdir for your mocks.  Set this to e.g. "sys" in order to

--- a/docs/CMock_Summary.md
+++ b/docs/CMock_Summary.md
@@ -287,6 +287,9 @@ Defined in the yaml file, they look more like this:
 * `:mock_suffix`:
   The suffix to append to your mock files. Defaults to “”.
 
+* `:weak_mocks`:
+  When set to true, the generated mocks are defined as weak symbols. Defaults to false.
+
 * `:subdir`:
   Relative subdir for your mocks.  Set this to e.g. "sys" in order to
   create mock for `sys/types.h` in `:mock_path`/sys/

--- a/lib/cmock_config.rb
+++ b/lib/cmock_config.rb
@@ -12,6 +12,7 @@ class CMockConfig
     :mock_path                   => 'mocks',
     :mock_prefix                 => 'Mock',
     :mock_suffix                 => '',
+    :weak_mocks                  => false,
     :subdir                      => nil,
     :plugins                     => [],
     :strippables                 => ['(?:__attribute__\s*\(+.*?\)+)'],

--- a/lib/cmock_config.rb
+++ b/lib/cmock_config.rb
@@ -12,7 +12,7 @@ class CMockConfig
     :mock_path                   => 'mocks',
     :mock_prefix                 => 'Mock',
     :mock_suffix                 => '',
-    :weak_mocks                  => false,
+    :weak                        => '',
     :subdir                      => nil,
     :plugins                     => [],
     :strippables                 => ['(?:__attribute__\s*\(+.*?\)+)'],

--- a/lib/cmock_generator.rb
+++ b/lib/cmock_generator.rb
@@ -15,7 +15,7 @@ class CMockGenerator
     @config      = config
     @prefix      = @config.mock_prefix
     @suffix      = @config.mock_suffix
-    @weak        = @config.weak_mocks
+    @weak        = @config.weak
     @ordered     = @config.enforce_strict_ordering
     @framework   = @config.framework.to_s
 
@@ -207,8 +207,12 @@ class CMockGenerator
     args_string += (", " + function[:var_arg]) unless (function[:var_arg].nil?)
 
     # Create mock function
-    if (@weak)
-        file << "#{function_mod_and_rettype} #{function[:name]}(#{args_string}) __attribute ((weak));\n"
+    if (not @weak.empty?)
+        file << "#if defined (__IAR_SYSTEMS_ICC__)\n"
+        file << "#pragma weak #{function[:name]}\n"
+        file << "#else\n"
+        file << "#{function_mod_and_rettype} #{function[:name]}(#{args_string}) #{weak};\n"
+        file << "#endif\n\n"
     end
     file << "#{function_mod_and_rettype} #{function[:name]}(#{args_string})\n"
     file << "{\n"

--- a/lib/cmock_generator.rb
+++ b/lib/cmock_generator.rb
@@ -6,7 +6,7 @@
 
 class CMockGenerator
 
-  attr_accessor :config, :file_writer, :module_name, :clean_mock_name, :mock_name, :utils, :plugins, :ordered
+  attr_accessor :config, :file_writer, :module_name, :clean_mock_name, :mock_name, :utils, :plugins, :weak, :ordered
 
   def initialize(config, file_writer, utils, plugins)
     @file_writer = file_writer
@@ -15,6 +15,7 @@ class CMockGenerator
     @config      = config
     @prefix      = @config.mock_prefix
     @suffix      = @config.mock_suffix
+    @weak        = @config.weak_mocks
     @ordered     = @config.enforce_strict_ordering
     @framework   = @config.framework.to_s
 
@@ -206,6 +207,9 @@ class CMockGenerator
     args_string += (", " + function[:var_arg]) unless (function[:var_arg].nil?)
 
     # Create mock function
+    if (@weak)
+        file << "#{function_mod_and_rettype} #{function[:name]}(#{args_string}) __attribute ((weak));\n"
+    end
     file << "#{function_mod_and_rettype} #{function[:name]}(#{args_string})\n"
     file << "{\n"
     file << "  UNITY_LINE_TYPE cmock_line = TEST_LINE_NUM;\n"

--- a/test/unit/cmock_generator_main_test.rb
+++ b/test/unit/cmock_generator_main_test.rb
@@ -44,7 +44,7 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
     #no strict handling
     @config.expect :mock_prefix, "Mock"
     @config.expect :mock_suffix, ""
-    @config.expect :weak_mocks, false
+    @config.expect :weak, ""
     @config.expect :enforce_strict_ordering, nil
     @config.expect :framework, :unity
     @config.expect :includes, ["ConfigRequiredHeader1.h","ConfigRequiredHeader2.h"]
@@ -61,7 +61,7 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
     #strict handling
     @config.expect :mock_prefix, "Mock"
     @config.expect :mock_suffix, ""
-    @config.expect :weak_mocks, false
+    @config.expect :weak, ""
     @config.expect :enforce_strict_ordering, true
     @config.expect :framework, :unity
     @config.expect :includes, nil
@@ -82,7 +82,7 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
   it "create the top of a header file with optional include files from config and include file from plugin" do
     @config.expect :mock_prefix, "Mock"
     @config.expect :mock_suffix, ""
-    @config.expect :weak_mocks, false
+    @config.expect :weak, ""
     orig_filename = "PoutPoutFish.h"
     define_name = "MOCKPOUTPOUTFISH_H"
     mock_name = "MockPoutPoutFish"
@@ -119,7 +119,7 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
     #no strict handling
     @config.expect :mock_prefix, "Mock"
     @config.expect :mock_suffix, ""
-    @config.expect :weak_mocks, false
+    @config.expect :weak, ""
     @config.expect :enforce_strict_ordering, nil
     @config.expect :framework, :unity
     @config.expect :includes, ["ConfigRequiredHeader1.h","ConfigRequiredHeader2.h"]
@@ -134,7 +134,7 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
 
     @config.expect :mock_prefix, "Mock"
     @config.expect :mock_suffix, ""
-    @config.expect :weak_mocks, false
+    @config.expect :weak, ""
     orig_filename = "Pout-Pout Fish.h"
     define_name = "MOCKPOUT_POUT_FISH_H"
     mock_name = "MockPout_Pout_Fish"
@@ -170,7 +170,7 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
   it "create the top of a header file with optional include files from config" do
     @config.expect :mock_prefix, "Mock"
     @config.expect :mock_suffix, ""
-    @config.expect :weak_mocks, false
+    @config.expect :weak, ""
     orig_filename = "PoutPoutFish.h"
     define_name = "MOCKPOUTPOUTFISH_H"
     mock_name = "MockPoutPoutFish"
@@ -205,7 +205,7 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
   it "create the top of a header file with include file from plugin" do
     @config.expect :mock_prefix, "Mock"
     @config.expect :mock_suffix, ""
-    @config.expect :weak_mocks, false
+    @config.expect :weak, ""
     orig_filename = "PoutPoutFish.h"
     define_name = "MOCKPOUTPOUTFISH_H"
     mock_name = "MockPoutPoutFish"

--- a/test/unit/cmock_generator_main_test.rb
+++ b/test/unit/cmock_generator_main_test.rb
@@ -44,6 +44,7 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
     #no strict handling
     @config.expect :mock_prefix, "Mock"
     @config.expect :mock_suffix, ""
+    @config.expect :weak_mocks, false
     @config.expect :enforce_strict_ordering, nil
     @config.expect :framework, :unity
     @config.expect :includes, ["ConfigRequiredHeader1.h","ConfigRequiredHeader2.h"]
@@ -60,6 +61,7 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
     #strict handling
     @config.expect :mock_prefix, "Mock"
     @config.expect :mock_suffix, ""
+    @config.expect :weak_mocks, false
     @config.expect :enforce_strict_ordering, true
     @config.expect :framework, :unity
     @config.expect :includes, nil
@@ -80,6 +82,7 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
   it "create the top of a header file with optional include files from config and include file from plugin" do
     @config.expect :mock_prefix, "Mock"
     @config.expect :mock_suffix, ""
+    @config.expect :weak_mocks, false
     orig_filename = "PoutPoutFish.h"
     define_name = "MOCKPOUTPOUTFISH_H"
     mock_name = "MockPoutPoutFish"
@@ -116,6 +119,7 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
     #no strict handling
     @config.expect :mock_prefix, "Mock"
     @config.expect :mock_suffix, ""
+    @config.expect :weak_mocks, false
     @config.expect :enforce_strict_ordering, nil
     @config.expect :framework, :unity
     @config.expect :includes, ["ConfigRequiredHeader1.h","ConfigRequiredHeader2.h"]
@@ -130,6 +134,7 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
 
     @config.expect :mock_prefix, "Mock"
     @config.expect :mock_suffix, ""
+    @config.expect :weak_mocks, false
     orig_filename = "Pout-Pout Fish.h"
     define_name = "MOCKPOUT_POUT_FISH_H"
     mock_name = "MockPout_Pout_Fish"
@@ -165,6 +170,7 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
   it "create the top of a header file with optional include files from config" do
     @config.expect :mock_prefix, "Mock"
     @config.expect :mock_suffix, ""
+    @config.expect :weak_mocks, false
     orig_filename = "PoutPoutFish.h"
     define_name = "MOCKPOUTPOUTFISH_H"
     mock_name = "MockPoutPoutFish"
@@ -199,6 +205,7 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
   it "create the top of a header file with include file from plugin" do
     @config.expect :mock_prefix, "Mock"
     @config.expect :mock_suffix, ""
+    @config.expect :weak_mocks, false
     orig_filename = "PoutPoutFish.h"
     define_name = "MOCKPOUTPOUTFISH_H"
     mock_name = "MockPoutPoutFish"


### PR DESCRIPTION
We use cmock in this way

- generate mocked implementations for all public header files,
- compile these mocked implementations,
- archive (libmocks.a) all these mocked objects

This archive (libmocks.a) is passed to the linker of every unit test executable as the last library. So when the linker doesn't find a symbol which it needs, it takes the one from the archive. This results in all the functions under test being defined twice. Our gcc linker can cope with this as it takes the first symbol it can find on the command line, since libmocks.a is last, the mocked one will not be taken in this case.

As the linker finds the symbol twice, it spawns a warning. By defining the mocked symbols weak (optionally through configuration), any linker shouldn't take this weak symbol when a strong one is defined. This happens then independently from the order on the linker command line...