### PR TITLE
Clear Ignore flag when StubWithCallback is called

### DIFF
--- a/lib/cmock_generator_plugin_callback.rb
+++ b/lib/cmock_generator_plugin_callback.rb
@@ -79,9 +79,12 @@ class CMockGeneratorPluginCallback
 
   def mock_interfaces(function)
     func_name = function[:name]
-    "void #{func_name}_StubWithCallback(CMOCK_#{func_name}_CALLBACK Callback)\n{\n" +
-    "  Mock.#{func_name}_IgnoreBool = (int)0;\n" +
-    "  Mock.#{func_name}_CallbackFunctionPointer = Callback;\n}\n\n"
+    lines = ""
+    lines << "void #{func_name}_StubWithCallback(CMOCK_#{func_name}_CALLBACK Callback)\n{\n"
+    if @config.plugins.include? :ignore
+      lines << "  Mock.#{func_name}_IgnoreBool = (int)0;\n"
+    end
+    lines << "  Mock.#{func_name}_CallbackFunctionPointer = Callback;\n}\n\n"
   end
 
   def mock_destroy(function)

--- a/lib/cmock_generator_plugin_callback.rb
+++ b/lib/cmock_generator_plugin_callback.rb
@@ -80,6 +80,7 @@ class CMockGeneratorPluginCallback
   def mock_interfaces(function)
     func_name = function[:name]
     "void #{func_name}_StubWithCallback(CMOCK_#{func_name}_CALLBACK Callback)\n{\n" +
+	"  Mock.#{func_name}_IgnoreBool = (int)0;\n" +
     "  Mock.#{func_name}_CallbackFunctionPointer = Callback;\n}\n\n"
   end
 

--- a/lib/cmock_generator_plugin_callback.rb
+++ b/lib/cmock_generator_plugin_callback.rb
@@ -80,7 +80,7 @@ class CMockGeneratorPluginCallback
   def mock_interfaces(function)
     func_name = function[:name]
     "void #{func_name}_StubWithCallback(CMOCK_#{func_name}_CALLBACK Callback)\n{\n" +
-	"  Mock.#{func_name}_IgnoreBool = (int)0;\n" +
+    "  Mock.#{func_name}_IgnoreBool = (int)0;\n" +
     "  Mock.#{func_name}_CallbackFunctionPointer = Callback;\n}\n\n"
   end
 

--- a/test/unit/cmock_generator_plugin_callback_test.rb
+++ b/test/unit/cmock_generator_plugin_callback_test.rb
@@ -14,6 +14,7 @@ describe CMockGeneratorPluginCallback, "Verify CMockGeneratorPluginCallback Modu
 
     @config.expect :callback_include_count, true
     @config.expect :callback_after_arg_check, false
+    @config.expect :plugins, [:ignore]
 
     @cmock_generator_plugin_callback = CMockGeneratorPluginCallback.new(@config, @utils)
   end

--- a/test/unit/cmock_generator_plugin_callback_test.rb
+++ b/test/unit/cmock_generator_plugin_callback_test.rb
@@ -240,6 +240,7 @@ describe CMockGeneratorPluginCallback, "Verify CMockGeneratorPluginCallback Modu
 
     expected = ["void Lemon_StubWithCallback(CMOCK_Lemon_CALLBACK Callback)\n",
                 "{\n",
+                "  Mock.Lemon_IgnoreBool = (int)0;\n",
                 "  Mock.Lemon_CallbackFunctionPointer = Callback;\n",
                 "}\n\n"
                ].join


### PR DESCRIPTION
When `StubWithCallback` is called, clear the `Ignore` flag otherwise the callback never gets called.