### PR TITLE
Check destination when returning thru ptr

### DIFF
--- a/lib/cmock_generator_plugin_return_thru_ptr.rb
+++ b/lib/cmock_generator_plugin_return_thru_ptr.rb
@@ -64,6 +64,7 @@ class CMockGeneratorPluginReturnThruPtr
       if (@utils.ptr_or_str?(arg[:type]) and not arg[:const?])
         lines << "  if (cmock_call_instance->ReturnThruPtr_#{arg_name}_Used)\n"
         lines << "  {\n"
+        lines << "    UNITY_TEST_ASSERT_NOT_NULL(#{arg_name}, cmock_line, CMockStringPtrIsNULL);\n"
         lines << "    memcpy(#{arg_name}, cmock_call_instance->ReturnThruPtr_#{arg_name}_Val,\n"
         lines << "      cmock_call_instance->ReturnThruPtr_#{arg_name}_Size);\n"
         lines << "  }\n"

--- a/src/cmock.c
+++ b/src/cmock.c
@@ -16,6 +16,7 @@ const char* CMockStringCalledLate  = "Called later than expected.";
 const char* CMockStringCallOrder   = "Called out of order.";
 const char* CMockStringIgnPreExp   = "IgnoreArg called before Expect.";
 const char* CMockStringPtrPreExp   = "ReturnThruPtr called before Expect.";
+const char* CMockStringPtrIsNULL   = "Pointer is NULL.";
 const char* CMockStringExpNULL     = "Expected NULL.";
 const char* CMockStringMismatch    = "Function called with unexpected argument value.";
 

--- a/src/cmock_internals.h
+++ b/src/cmock_internals.h
@@ -16,6 +16,7 @@ extern const char* CMockStringCalledLate;
 extern const char* CMockStringCallOrder;
 extern const char* CMockStringIgnPreExp;
 extern const char* CMockStringPtrPreExp;
+extern const char* CMockStringPtrIsNULL;
 extern const char* CMockStringExpNULL;
 extern const char* CMockStringMismatch;
 


### PR DESCRIPTION
This adds a check that the destination is not `NULL` when using the ReturnThruPtr-plugin.