### PR TITLE
Improve handling of brackets in function params

### DIFF
--- a/lib/cmock_header_parser.rb
+++ b/lib/cmock_header_parser.rb
@@ -187,9 +187,9 @@ class CMockHeaderParser
       return 'void'
     else
       c=0
-      arg_list.gsub!(/(\w+)(?:\s*\[[\s\d\w+-]*\])+/,'*\1')  # magically turn brackets into asterisks
-      arg_list.gsub!(/\s+\*/,'*')                           # remove space to place asterisks with type (where they belong)
-      arg_list.gsub!(/\*(\w)/,'* \1')                       # pull asterisks away from arg to place asterisks with type (where they belong)
+      arg_list.gsub!(/(\w+)(?:\s*\[\(*[\s\d\w+-]*\)*\])+/,'*\1')  # magically turn brackets into asterisks, also match for parentheses that come from macros
+      arg_list.gsub!(/\s+\*/,'*')                                 # remove space to place asterisks with type (where they belong)
+      arg_list.gsub!(/\*(\w)/,'* \1')                             # pull asterisks away from arg to place asterisks with type (where they belong)
 
       #scan argument list for function pointers and replace them with custom types
       arg_list.gsub!(/([\w\s\*]+)\(+\s*\*[\*\s]*([\w\s]*)\s*\)+\s*\(((?:[\w\s\*]*,?)*)\s*\)*/) do |m|

--- a/lib/cmock_header_parser.rb
+++ b/lib/cmock_header_parser.rb
@@ -187,9 +187,9 @@ class CMockHeaderParser
       return 'void'
     else
       c=0
-      arg_list.gsub!(/(\w+)(?:\s*\[\(*[\s\d\w+-]*\)*\])+/,'*\1')  # magically turn brackets into asterisks, also match for parentheses that come from macros
-      arg_list.gsub!(/\s+\*/,'*')                                 # remove space to place asterisks with type (where they belong)
-      arg_list.gsub!(/\*(\w)/,'* \1')                             # pull asterisks away from arg to place asterisks with type (where they belong)
+      arg_list.gsub!(/(\w+)(?:\s*\[\s*\(*[\s\d\w+-]*\)*\s*\])+/,'*\1')  # magically turn brackets into asterisks, also match for parentheses that come from macros
+      arg_list.gsub!(/\s+\*/,'*')                                       # remove space to place asterisks with type (where they belong)
+      arg_list.gsub!(/\*(\w)/,'* \1')                                   # pull asterisks away from arg to place asterisks with type (where they belong)
 
       #scan argument list for function pointers and replace them with custom types
       arg_list.gsub!(/([\w\s\*]+)\(+\s*\*[\*\s]*([\w\s]*)\s*\)+\s*\(((?:[\w\s\*]*,?)*)\s*\)*/) do |m|

--- a/test/system/test_interactions/parsing_challenges.yml
+++ b/test/system/test_interactions/parsing_challenges.yml
@@ -65,6 +65,7 @@
     void oh_brackets1(int fudge[5]);
     void oh_brackets2(int caramel[]);
     void oh_brackets3(int toffee[(32)]);
+    void oh_brackets4(int taffy[ (64) ]);
     #ifdef __cplusplus
     }
     #endif

--- a/test/system/test_interactions/parsing_challenges.yml
+++ b/test/system/test_interactions/parsing_challenges.yml
@@ -64,6 +64,7 @@
 
     void oh_brackets1(int fudge[5]);
     void oh_brackets2(int caramel[]);
+    void oh_brackets3(int toffee[(32)]);
     #ifdef __cplusplus
     }
     #endif


### PR DESCRIPTION
This should resolve #93 

During header parsing, #define substitutions in fixed-length array
function parameters can have parentheses in them which can cause a
failure in the bracket->asterisk conversion that happens during the
mocking process. This change updates the regex to also match for
parentheses in the function parameter brackets to ensure they get
swapped out.