### PR TITLE
Suppress warning when returning thru const or volatile ptr

### DIFF
--- a/lib/cmock_generator_plugin_return_thru_ptr.rb
+++ b/lib/cmock_generator_plugin_return_thru_ptr.rb
@@ -65,7 +65,7 @@ class CMockGeneratorPluginReturnThruPtr
         lines << "  if (cmock_call_instance->ReturnThruPtr_#{arg_name}_Used)\n"
         lines << "  {\n"
         lines << "    UNITY_TEST_ASSERT_NOT_NULL(#{arg_name}, cmock_line, CMockStringPtrIsNULL);\n"
-        lines << "    memcpy(#{arg_name}, cmock_call_instance->ReturnThruPtr_#{arg_name}_Val,\n"
+        lines << "    memcpy((void*)#{arg_name}, (void*)cmock_call_instance->ReturnThruPtr_#{arg_name}_Val,\n"
         lines << "      cmock_call_instance->ReturnThruPtr_#{arg_name}_Size);\n"
         lines << "  }\n"
       end


### PR DESCRIPTION
GCC gives a warning:
```
  warning: passing argument 1 of 'memcpy' discards 'const volatile'
  qualifier from pointer target type
```

and the same for argument 2. These additional casts suppress the
warning.