### PR TITLE
Bugfixes + improvements in makefile-based scripts

### DIFF
--- a/scripts/create_makefile.rb
+++ b/scripts/create_makefile.rb
@@ -68,7 +68,7 @@ File.open(TEST_MAKEFILE, "w") do |mkfile|
     runner_source = File.join(RUNNERS_DIR, "runner_#{module_name}.c")
     runner_obj = File.join(OBJ_DIR, "runner_#{module_name}.o")
     test_bin = File.join(TEST_BIN_DIR, module_name)
-    test_results = File.join(TEST_BIN_DIR, module_name + '.result')
+    test_results = File.join(TEST_BIN_DIR, module_name + '.testresult')
 
     cfg = {
       src: test,
@@ -180,7 +180,7 @@ File.open(TEST_MAKEFILE, "w") do |mkfile|
   mkfile.puts ""
 
   # Create target to run all tests
-  mkfile.puts "test: #{test_targets.map{|t| t + '.result'}.join(' ')} test_summary"
+  mkfile.puts "test: #{test_targets.map{|t| t + '.testresult'}.join(' ')} test_summary"
   mkfile.puts ""
 
 end

--- a/scripts/create_makefile.rb
+++ b/scripts/create_makefile.rb
@@ -58,7 +58,7 @@ File.open(TEST_MAKEFILE, "w") do |mkfile|
   test_sources = Dir["#{TEST_DIR}/**/test_*.c"]
   test_targets = []
   generator = UnityTestRunnerGenerator.new
-  all_headers = Dir["#{SRC_DIR}/**/*.h"]
+  all_headers = Dir["#{SRC_DIR}/**/{[!mock_]}*.h"]  #headers that begin with mock_ are not included
   makefile_targets = []
 
   test_sources.each do |test|
@@ -130,6 +130,7 @@ File.open(TEST_MAKEFILE, "w") do |mkfile|
       raise "Module header '#{name}' not found to mock!" unless header_to_mock
       headers_to_mock << header_to_mock
     end
+
     all_headers_to_mock += headers_to_mock
     mock_objs = headers_to_mock.map do |hdr|
       mock_name = MOCK_PREFIX + File.basename(hdr, '.h')

--- a/scripts/create_makefile.rb
+++ b/scripts/create_makefile.rb
@@ -150,7 +150,7 @@ File.open(TEST_MAKEFILE, "w") do |mkfile|
 
     # Run test suite and generate report
     mkfile.puts "#{test_results}: #{test_bin}"
-    mkfile.puts "\t-#{test_bin} &> #{test_results}"
+    mkfile.puts "\t-#{test_bin} > #{test_results} 2>&1"
     mkfile.puts ""
 
     test_targets << test_bin

--- a/scripts/test_summary.rb
+++ b/scripts/test_summary.rb
@@ -7,7 +7,7 @@ begin
   build_dir = ENV.fetch('BUILD_DIR', './build')
   test_build_dir = ENV.fetch('TEST_BUILD_DIR', File.join(build_dir, 'test'))
 
-  results = Dir["#{test_build_dir}/*.result"]
+  results = Dir["#{test_build_dir}/*.testresult"]
   parser = UnityTestSummary.new
   parser.targets = results
   parser.run


### PR DESCRIPTION
1.  Results files were getting created but had zero length.  Fixed.
2.  Results files were named .result which is not compatible with the other scripts (like the one that creates junit results) that expect at least the word 'test' to appear (".testfailed", ".testpassed") in results files.  We will now call them ".testresults" which will let the other collector scripts work properly.
3.  This was a bigger issue, if you have multiple tests and multiple mocks, I would mock_mock_mock_mock_foo.c if I ran the makefile several times.  To fix this I exclude any headers with the word mock_ from the analysis.