### PR TITLE
Push and pop GCC diagnostics to maintain scope for changed warning flags

### DIFF
--- a/lib/cmock_generator.rb
+++ b/lib/cmock_generator.rb
@@ -102,6 +102,7 @@ class CMockGenerator
     file << "\n"
     file << "/* Ignore the following warnings, since we are copying code */\n"
     file << "#if defined(__GNUC__) && !defined(__ICC) && !defined(__TMS470__)\n"
+    file << "#pragma GCC diagnostic push\n"
     file << "#if !defined(__clang__)\n"
     file << "#pragma GCC diagnostic ignored \"-Wpragmas\"\n"
     file << "#endif\n"
@@ -124,7 +125,12 @@ class CMockGenerator
   end
 
   def create_mock_header_footer(header)
-    header << "\n#endif\n"
+    header << "\n"
+    header << "#if defined(__GNUC__) && !defined(__ICC) && !defined(__TMS470__)\n"
+    header << "#pragma GCC diagnostic pop\n"
+    header << "#endif\n"
+    header << "\n"
+    header << "#endif\n"
   end
 
   def create_source_header_section(file, filename, functions)

--- a/test/unit/cmock_generator_main_test.rb
+++ b/test/unit/cmock_generator_main_test.rb
@@ -98,6 +98,7 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
       "\n",
       "/* Ignore the following warnings, since we are copying code */\n",
       "#if defined(__GNUC__) && !defined(__ICC) && !defined(__TMS470__)\n",
+      "#pragma GCC diagnostic push\n",
       "#if !defined(__clang__)\n",
       "#pragma GCC diagnostic ignored \"-Wpragmas\"\n",
       "#endif\n",
@@ -150,6 +151,7 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
       "\n",
       "/* Ignore the following warnings, since we are copying code */\n",
       "#if defined(__GNUC__) && !defined(__ICC) && !defined(__TMS470__)\n",
+      "#pragma GCC diagnostic push\n",
       "#if !defined(__clang__)\n",
       "#pragma GCC diagnostic ignored \"-Wpragmas\"\n",
       "#endif\n",
@@ -185,6 +187,7 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
       "\n",
       "/* Ignore the following warnings, since we are copying code */\n",
       "#if defined(__GNUC__) && !defined(__ICC) && !defined(__TMS470__)\n",
+      "#pragma GCC diagnostic push\n",
       "#if !defined(__clang__)\n",
       "#pragma GCC diagnostic ignored \"-Wpragmas\"\n",
       "#endif\n",
@@ -221,6 +224,7 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
       "\n",
       "/* Ignore the following warnings, since we are copying code */\n",
       "#if defined(__GNUC__) && !defined(__ICC) && !defined(__TMS470__)\n",
+      "#pragma GCC diagnostic push\n",
       "#if !defined(__clang__)\n",
       "#pragma GCC diagnostic ignored \"-Wpragmas\"\n",
       "#endif\n",
@@ -272,7 +276,13 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
 
   it "append the proper footer to the header file" do
     output = []
-    expected = ["\n#endif\n"]
+    expected = ["\n",
+                "#if defined(__GNUC__) && !defined(__ICC) && !defined(__TMS470__)\n",
+                "#pragma GCC diagnostic pop\n",
+                "#endif\n",
+                "\n",
+                "#endif\n"
+                ]
 
     @cmock_generator.create_mock_header_footer(output)
 


### PR DESCRIPTION
The GCC diagnostics `#pragma`s in the header files aren't pushed, and as a result, they'll affect the compilation of all files that include the header. This can lead to missed warnings in the test files. 

This PR adds push/pop to avoid altering diagnostics for including files. 