### PR TITLE
Add 'strict_mock_calling' option

### DIFF
--- a/docs/CMock_Summary.md
+++ b/docs/CMock_Summary.md
@@ -541,6 +541,21 @@ from the defaults. We've tried to specify what the defaults are below.
   
   * default: :smart
 
+* `:strict_mock_calling`:
+  CMock always enforces you to specify what to do when a mocked function is called.
+  If you did not specify any action for the mocked function (no _Expect,_Ignore, ...),
+  the test will fail when the mocked function got called (because you did not specify an action!).
+
+  You might not want this behaviour.
+  You might want all calls to mock functions to be 'ignored' at the start of a test case.
+  You can then define actions for the mock functions you are interested in.
+  If so, set this to false.
+
+  * default: true
+  * **note:**
+    If this option is disabled, the mocked functions will return
+	a default value (0x0) when called (and only if they have to return something ofcourse).
+
 
 Compiled Options:
 -----------------

--- a/lib/cmock_config.rb
+++ b/lib/cmock_config.rb
@@ -19,6 +19,7 @@ class CMockConfig
     :attributes                  => ['__ramfunc', '__irq', '__fiq', 'register', 'extern'],
     :c_calling_conventions       => ['__stdcall', '__cdecl', '__fastcall'],
     :enforce_strict_ordering     => false,
+    :strict_mock_calling         => true,
     :unity_helper_path           => false,
     :treat_as                    => {},
     :treat_as_void               => [],

--- a/lib/cmock_generator.rb
+++ b/lib/cmock_generator.rb
@@ -18,6 +18,7 @@ class CMockGenerator
     @weak        = @config.weak
     @ordered     = @config.enforce_strict_ordering
     @framework   = @config.framework.to_s
+    @strict_mock_calling = @config.strict_mock_calling
 
     @subdir      = @config.subdir
 
@@ -202,6 +203,11 @@ class CMockGenerator
     file << "  CMock_Guts_MemFreeAll();\n"
     file << "  memset(&Mock, 0, sizeof(Mock));\n"
     file << functions.collect {|function| @plugins.run(:mock_destroy, function)}.join
+
+    unless (@strict_mock_calling)
+      file << functions.collect {|function| @plugins.run(:mock_ignore, function)}.join
+    end
+
     if (@ordered)
       file << "  GlobalExpectCount = 0;\n"
       file << "  GlobalVerifyOrder = 0;\n"

--- a/lib/cmock_generator_plugin_ignore.rb
+++ b/lib/cmock_generator_plugin_ignore.rb
@@ -65,6 +65,10 @@ class CMockGeneratorPluginIgnore
     lines << "}\n\n"
   end
 
+  def mock_ignore(function)
+    "  Mock.#{function[:name]}_IgnoreBool = (int) 1;\n"
+  end
+
   def mock_verify(function)
     func_name = function[:name]
     "  if (Mock.#{func_name}_IgnoreBool)\n    Mock.#{func_name}_CallInstance = CMOCK_GUTS_NONE;\n"

--- a/test/system/test_interactions/ignore_and_return.yml
+++ b/test/system/test_interactions/ignore_and_return.yml
@@ -159,4 +159,12 @@
           TEST_ASSERT_EQUAL(110, function(0, 8, 9));
         }
 
+    - :pass: FALSE
+      :should: 'Without "TODO" specified, Expect/Ignore/... of bar is required. Test should fail.'
+      :code: |
+        test()
+        {
+          function(1, 2, 3);
+        }
+
 ...

--- a/test/system/test_interactions/ignore_and_return.yml
+++ b/test/system/test_interactions/ignore_and_return.yml
@@ -160,7 +160,7 @@
         }
 
     - :pass: FALSE
-      :should: 'Without "TODO" specified, Expect/Ignore/... of bar is required. Test should fail.'
+      :should: 'With "strict_mock_calling" enabled, Expect/Ignore/... of bar is required and test fails.'
       :code: |
         test()
         {

--- a/test/system/test_interactions/ignore_strict_mock_calling.yml
+++ b/test/system/test_interactions/ignore_strict_mock_calling.yml
@@ -1,0 +1,37 @@
+---
+:cmock:
+  :plugins:
+  - 'ignore'
+  :strict_mock_calling: FALSE
+
+:systest:
+  :types: |
+
+  :mockable: |
+    int foo(int a);
+    void bar(int b);
+
+  :source:
+    :header: |
+      int function(int a, int b, int c);
+    :code: |
+      int function(int a, int b, int c)
+      {
+        bar(b);
+        return foo(a) + foo(b) + foo(c);
+      }
+
+  :tests:
+    :common: |
+      void setUp(void) {}
+      void tearDown(void) {}
+    :units:
+    - :pass: TRUE
+      :should: 'With "strict_mock_calling" disabled, Expect/Ignore/... of bar is NOT required.'
+      :code: |
+        test()
+        {
+          function(1, 2, 3);
+        }
+
+...

--- a/test/unit/cmock_generator_main_test.rb
+++ b/test/unit/cmock_generator_main_test.rb
@@ -53,6 +53,7 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
     @config.expect :includes_c_pre_header, nil
     @config.expect :includes_c_post_header, nil
     @config.expect :subdir, nil
+    @config.expect :strict_mock_calling, true
     @cmock_generator = CMockGenerator.new(@config, @file_writer, @utils, @plugins)
     @cmock_generator.module_name = @module_name
     @cmock_generator.mock_name = "Mock#{@module_name}"
@@ -70,6 +71,7 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
     @config.expect :includes_c_pre_header, nil
     @config.expect :includes_c_post_header, nil
     @config.expect :subdir, nil
+    @config.expect :strict_mock_calling, true
     @cmock_generator_strict = CMockGenerator.new(@config, @file_writer, @utils, @plugins)
     @cmock_generator_strict.module_name = @module_name
     @cmock_generator_strict.mock_name = "Mock#{@module_name}"
@@ -128,6 +130,7 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
     @config.expect :includes_c_pre_header, nil
     @config.expect :includes_c_post_header, nil
     @config.expect :subdir, nil
+    @config.expect :strict_mock_calling, true
     @cmock_generator2 = CMockGenerator.new(@config, @file_writer, @utils, @plugins)
     @cmock_generator2.module_name = "Pout-Pout Fish"
     @cmock_generator2.mock_name = "MockPout-Pout Fish"


### PR DESCRIPTION
Add strict_mock_calling option to ignore all mock calls by default,
unless user specifies Except/Ignore/... in test.
Related to #142 