### PR TITLE
Fix alignment error of CMock_Guts_Buffer (issue #66)

### DIFF
--- a/lib/cmock_generator_plugin_do_not_expect.rb
+++ b/lib/cmock_generator_plugin_do_not_expect.rb
@@ -1,0 +1,30 @@
+# ==========================================
+#   CMock Project - Automatic Mock Generation for C
+#   Copyright (c) 2015 ViCentra B.V.
+#   [Released under MIT License. Please refer to license.txt for details]
+# ==========================================
+
+class CMockGeneratorPluginDoNotExpect
+
+  attr_reader :priority
+  attr_reader :config
+
+  def initialize(config, utils)
+    @config = config
+    @priority = 20
+  end
+
+
+  def mock_function_declarations(function)
+    "#define #{function[:name]}_DoNotExpect() #{function[:name]}_CMockDoNotExpect()\n" +
+        "void #{function[:name]}_CMockDoNotExpect(void);\n"
+  end
+
+  def mock_interfaces(function)
+    lines = "void #{function[:name]}_CMockDoNotExpect(void)\n{\n"
+	lines << "  Mock.#{function[:name]}_IgnoreBool = (int)0;\n"
+	lines << "  Mock.#{function[:name]}_CallInstance = CMOCK_GUTS_NONE;\n"
+	lines << "}\n\n"
+  end
+end
+

--- a/src/cmock.c
+++ b/src/cmock.c
@@ -26,7 +26,8 @@ static unsigned char*         CMock_Guts_Buffer = NULL;
 static CMOCK_MEM_INDEX_TYPE   CMock_Guts_BufferSize = CMOCK_MEM_ALIGN_SIZE;
 static CMOCK_MEM_INDEX_TYPE   CMock_Guts_FreePtr;
 #else
-static unsigned char          CMock_Guts_Buffer[CMOCK_MEM_SIZE + CMOCK_MEM_ALIGN_SIZE];
+static CMOCK_MEM_INDEX_TYPE   CMock_Guts_BufferArray[(CMOCK_MEM_SIZE + CMOCK_MEM_INDEX_SIZE - 1) / CMOCK_MEM_INDEX_SIZE];
+#define CMock_Guts_Buffer ((unsigned char*)CMock_Guts_BufferArray)
 static CMOCK_MEM_INDEX_TYPE   CMock_Guts_BufferSize = CMOCK_MEM_SIZE + CMOCK_MEM_ALIGN_SIZE;
 static CMOCK_MEM_INDEX_TYPE   CMock_Guts_FreePtr;
 #endif


### PR DESCRIPTION
Changed static allocation to use CMOCK_MEM_INDEX_TYPE instead of unsigned char. This may allocate extra memory if CMOCK_MEM_SIZE  is not a multiple of CMOCK_MEM_INDEX_SIZE. Had to substitute CMock_Guts_Buffer with a define in this case, because pointers to arrays are not compile time constants and cannot be assigned at initialization. This isn't a perfect solution but it solves the alignment issue for us.