### PR TITLE
mock_Verify functions should ideally not modify the state of the mock.

### DIFF
--- a/lib/cmock_generator.rb
+++ b/lib/cmock_generator.rb
@@ -190,9 +190,15 @@ class CMockGenerator
 
   def create_mock_verify_function(file, functions)
     file << "void #{@clean_mock_name}_Verify(void)\n{\n"
-    verifications = functions.collect {|function| @plugins.run(:mock_verify, function)}.join
-    file << "  UNITY_LINE_TYPE cmock_line = TEST_LINE_NUM;\n" unless verifications.empty?
-    file << verifications
+    verifications = functions.collect do |function|
+      v = @plugins.run(:mock_verify, function)
+      v.empty? ? v : ["  call_instance = Mock.#{function[:name]}_CallInstance;\n", v]
+    end.join
+    unless verifications.empty?
+      file << "  UNITY_LINE_TYPE cmock_line = TEST_LINE_NUM;\n"
+      file << "  CMOCK_MEM_INDEX_TYPE call_instance;\n"
+      file << verifications
+    end
     file << "}\n\n"
   end
 

--- a/lib/cmock_generator_plugin_callback.rb
+++ b/lib/cmock_generator_plugin_callback.rb
@@ -92,7 +92,7 @@ class CMockGeneratorPluginCallback
 
   def mock_verify(function)
     func_name = function[:name]
-    "  if (Mock.#{func_name}_CallbackFunctionPointer != NULL)\n    Mock.#{func_name}_CallInstance = CMOCK_GUTS_NONE;\n"
+    "  if (Mock.#{func_name}_CallbackFunctionPointer != NULL)\n    call_instance = CMOCK_GUTS_NONE;\n"
   end
 
 end

--- a/lib/cmock_generator_plugin_expect.rb
+++ b/lib/cmock_generator_plugin_expect.rb
@@ -98,7 +98,7 @@ class CMockGeneratorPluginExpect
   def mock_verify(function)
     func_name = function[:name]
     "  UNITY_SET_DETAIL(CMockString_#{function[:name]});\n" +
-    "  UNITY_TEST_ASSERT(CMOCK_GUTS_NONE == Mock.#{func_name}_CallInstance, cmock_line, CMockStringCalledLess);\n"
+    "  UNITY_TEST_ASSERT(CMOCK_GUTS_NONE == call_instance, cmock_line, CMockStringCalledLess);\n"
   end
 
 end

--- a/lib/cmock_generator_plugin_ignore.rb
+++ b/lib/cmock_generator_plugin_ignore.rb
@@ -70,6 +70,6 @@ class CMockGeneratorPluginIgnore
 
   def mock_verify(function)
     func_name = function[:name]
-    "  if (Mock.#{func_name}_IgnoreBool)\n    Mock.#{func_name}_CallInstance = CMOCK_GUTS_NONE;\n"
+    "  if (Mock.#{func_name}_IgnoreBool)\n    call_instance = CMOCK_GUTS_NONE;\n"
   end
 end

--- a/test/unit/cmock_generator_main_test.rb
+++ b/test/unit/cmock_generator_main_test.rb
@@ -409,8 +409,11 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
     output = []
     expected = [ "void MockPoutPoutFish_Verify(void)\n{\n",
                  "  UNITY_LINE_TYPE cmock_line = TEST_LINE_NUM;\n",
+                 "  CMOCK_MEM_INDEX_TYPE call_instance;\n",
+                 "  call_instance = Mock.First_CallInstance;\n" +
                  "  Uno_First" +
                  "  Dos_First" +
+                 "  call_instance = Mock.Second_CallInstance;\n" +
                  "  Uno_Second" +
                  "  Dos_Second",
                  "}\n\n"

--- a/test/unit/cmock_generator_plugin_expect_a_test.rb
+++ b/test/unit/cmock_generator_plugin_expect_a_test.rb
@@ -179,7 +179,7 @@ describe CMockGeneratorPluginExpect, "Verify CMockGeneratorPluginExpect Module W
   it "add mock verify lines" do
     function = {:name => "Banana" }
     expected = "  UNITY_SET_DETAIL(CMockString_Banana);\n" +
-               "  UNITY_TEST_ASSERT(CMOCK_GUTS_NONE == Mock.Banana_CallInstance, cmock_line, CMockStringCalledLess);\n"
+               "  UNITY_TEST_ASSERT(CMOCK_GUTS_NONE == call_instance, cmock_line, CMockStringCalledLess);\n"
     returned = @cmock_generator_plugin_expect.mock_verify(function)
     assert_equal(expected, returned)
   end

--- a/test/unit/cmock_generator_plugin_expect_b_test.rb
+++ b/test/unit/cmock_generator_plugin_expect_b_test.rb
@@ -195,7 +195,7 @@ describe CMockGeneratorPluginExpect, "Verify CMockGeneratorPluginExpect Module w
   it "add mock verify lines" do
     function = {:name => "Banana" }
     expected = "  UNITY_SET_DETAIL(CMockString_Banana);\n" +
-               "  UNITY_TEST_ASSERT(CMOCK_GUTS_NONE == Mock.Banana_CallInstance, cmock_line, CMockStringCalledLess);\n"
+               "  UNITY_TEST_ASSERT(CMOCK_GUTS_NONE == call_instance, cmock_line, CMockStringCalledLess);\n"
     returned = @cmock_generator_plugin_expect.mock_verify(function)
     assert_equal(expected, returned)
   end


### PR DESCRIPTION
In typical unit tests, this doesn't matter since the Verify functions
are called only from the end of the test.  However, in longer integration
tests, where a sequence of function calls is to be tested, it's handy
to be able to verify the Expects halfway through the test.  This change
is a first step in making that possible.