### PR TITLE
Detect array_data,array_size pattern when generating mock

### DIFF
--- a/lib/cmock_config.rb
+++ b/lib/cmock_config.rb
@@ -36,6 +36,8 @@ class CMockConfig
     :includes_c_pre_header       => nil,
     :includes_c_post_header      => nil,
     :orig_header_include_fmt     => "#include \"%s\"",
+    :array_size_type             => [],
+    :array_size_name             => 'size|len',
   }
 
   def initialize(options=nil)

--- a/lib/cmock_generator_utils.rb
+++ b/lib/cmock_generator_utils.rb
@@ -100,7 +100,13 @@ class CMockGeneratorUtils
   def code_call_argument_loader(function)
     if (function[:args_string] != "void")
       args = function[:args].map do |m|
-        (@arrays and m[:ptr?]) ? "#{m[:name]}, 1" : m[:name]
+        if (@arrays and m[:ptr?] and not m[:array_data?])
+          "#{m[:name]}, 1"
+        elsif (@arrays and m[:array_size?])
+          "#{m[:name]}, #{m[:name]}"
+        else
+          m[:name]
+        end
       end
       "  CMockExpectParameters_#{function[:name]}(cmock_call_instance, #{args.join(', ')});\n"
     else

--- a/lib/cmock_header_parser.rb
+++ b/lib/cmock_header_parser.rb
@@ -17,6 +17,8 @@ class CMockHeaderParser
     @treat_as_void = (['void'] + cfg.treat_as_void).uniq
     @declaration_parse_matcher = /([\d\w\s\*\(\),\[\]]+??)\(([\d\w\s\*\(\),\.\[\]+-]*)\)$/m
     @standards = (['int','short','char','long','unsigned','signed'] + cfg.treat_as.keys).uniq
+    @array_size_name = cfg.array_size_name
+    @array_size_type = (['int', 'size_t'] + cfg.array_size_type).uniq
     @when_no_prototypes = cfg.when_no_prototypes
     @local_as_void = @treat_as_void
     @verbosity = cfg.verbosity
@@ -186,6 +188,18 @@ class CMockHeaderParser
       arg_info.delete(:c_calling_convention) # don't care about this
       args << arg_info
     end
+
+    # Try to find array pair in parameters following this pattern : <type> * <name>, <@array_size_type> <@array_size_name>
+    args.each_with_index {|val, index|
+      next_index = index + 1
+      if (args.length > next_index)
+        if (val[:ptr?] == true and args[next_index][:name].match(@array_size_name) and @array_size_type.include?(args[next_index][:type]))
+          val[:array_data?] = true
+          args[next_index][:array_size?] = true
+        end
+      end
+    }
+
     return args
   end
 

--- a/test/unit/cmock_header_parser_test.rb
+++ b/test/unit/cmock_header_parser_test.rb
@@ -22,6 +22,8 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
     @config.expect :when_no_prototypes, :error
     @config.expect :verbosity, 1
     @config.expect :treat_externs, :exclude
+    @config.expect :array_size_type, ['int', 'size_t']
+    @config.expect :array_size_name, 'size|len'
 
     @parser = CMockHeaderParser.new(@config)
   end


### PR DESCRIPTION
Try to find 'array pair' in parameters following this pattern : <type> * <name>, <@array_size_type> <@array_size_name>
When such a pattern is used, the second parameter is used as the array size in _Expect method.

Shall fix #189 