### PR TITLE
Clean up example makefile

### DIFF
--- a/examples/make_example/Makefile
+++ b/examples/make_example/Makefile
@@ -1,8 +1,8 @@
 CC ?= gcc
-BUILD_DIR ?= ./build
-SRC_DIR ?= ./src
-TEST_DIR ?= ./test
-TEST_BUILD_DIR ?= ${BUILD_DIR}/test
+export BUILD_DIR ?= ./build
+export SRC_DIR ?= ./src
+export TEST_DIR ?= ./test
+export TEST_BUILD_DIR ?= ${BUILD_DIR}/test
 TEST_MAKEFILE = ${TEST_BUILD_DIR}/MakefileTestSupport
 OBJ ?= ${BUILD_DIR}/obj
 OBJ_DIR = ${OBJ}

--- a/scripts/create_makefile.rb
+++ b/scripts/create_makefile.rb
@@ -34,13 +34,13 @@ File.open(TEST_MAKEFILE, "w") do |mkfile|
 
   # Define make variables
   mkfile.puts "CC ?= gcc"
-  mkfile.puts "BUILD_DIR ?= ./build"
-  mkfile.puts "SRC_DIR ?= ./src"
-  mkfile.puts "TEST_DIR ?= ./test"
+  mkfile.puts "BUILD_DIR = #{BUILD_DIR}"
+  mkfile.puts "SRC_DIR = #{SRC_DIR}"
+  mkfile.puts "TEST_DIR = #{TEST_DIR}"
   mkfile.puts "TEST_CFLAGS ?= -DTEST"
   mkfile.puts "CMOCK_DIR ?= #{CMOCK_DIR}"
   mkfile.puts "UNITY_DIR ?= #{UNITY_DIR}"
-  mkfile.puts "TEST_BUILD_DIR ?= ${BUILD_DIR}/test"
+  mkfile.puts "TEST_BUILD_DIR = ${TEST_BUILD_DIR}"
   mkfile.puts "TEST_MAKEFILE = ${TEST_BUILD_DIR}/MakefileTestSupport"
   mkfile.puts "OBJ ?= ${BUILD_DIR}/obj"
   mkfile.puts "OBJ_DIR = ${OBJ}"
@@ -96,7 +96,7 @@ File.open(TEST_MAKEFILE, "w") do |mkfile|
     if not makefile_targets.include? module_obj
         makefile_targets.push(module_obj)
         mkfile.puts "#{module_obj}: #{module_src}"
-        mkfile.puts "\t${CC} -o $@ -c $< ${TEST_CFLAGS} -I #{SRC_DIR} ${INCLUDE_PATH}"
+        mkfile.puts "\t${CC} -o $@ -c $< ${TEST_CFLAGS} -I ${SRC_DIR} ${INCLUDE_PATH}"
         mkfile.puts ""
     end
 
@@ -112,7 +112,7 @@ File.open(TEST_MAKEFILE, "w") do |mkfile|
         if not makefile_targets.include? linkonlymodule_obj
             makefile_targets.push(linkonlymodule_obj)
             mkfile.puts "#{linkonlymodule_obj}: #{linkonlymodule_src}"
-            mkfile.puts "\t${CC} -o $@ -c $< ${TEST_CFLAGS} -I #{SRC_DIR} ${INCLUDE_PATH}"
+            mkfile.puts "\t${CC} -o $@ -c $< ${TEST_CFLAGS} -I ${SRC_DIR} ${INCLUDE_PATH}"
             mkfile.puts ""
         end
     end


### PR DESCRIPTION
I found something in the example makefile that I think could cause confusion. To demonstrate, if you change the name of the example `src` directory to `source` and then modify the example make file so that `SRC_DIR ?= source` and run it the project will not compile. That is because the makefile calls a `create_makefile.rb` which attempts to read the SRC_DIR environment variable. However, just creating a variable in the makefile does not create an environment variable that the ruby process can access. I made some adjustments to fix that.

As it is, the example project only works because the directory structure happens to match the defaults that are specified in the `create_makefile.rb` script.