### PR TITLE
Fix bug where if folder "mocks" doesn't exist it fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,9 @@ os:
   - linux
 
 rvm:
-  - "2.2.2"
+  - "2.3"
 
 before_install:
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then rvm install 2.1 && rvm use 2.1 && ruby -v; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install --assume-yes --quiet gcc-multilib; fi
 
 install:

--- a/docs/CMock_Summary.md
+++ b/docs/CMock_Summary.md
@@ -153,7 +153,7 @@ only needs to be called once per test. It will then ignore any further calls to 
 particular mock. The IgnoreAndReturn works similarly, except that it has the added
 benefit of knowing what to return when that call happens. If the mock is called more
 times than IgnoreAndReturn was called, it will keep returning the last value without
-complaint. If it's called less times, it will also ignore that. You SAID you didn't
+complaint. If it's called fewer times, it will also ignore that. You SAID you didn't
 care how many times it was called, right?
 
 * `void func(void)` => `void func_Ignore(void)`
@@ -574,7 +574,7 @@ based on other settings, particularly Unity's settings.
 * `CMOCK_MEM_SIZE`
   In static mode this is the total amount of memory you are allocating
   to Cmock. In Dynamic mode this is the size of each chunk allocated
-  at once (larger numbers grab more memory but require less mallocs).
+  at once (larger numbers grab more memory but require fewer mallocs).
 
 * `CMOCK_MEM_ALIGN`
   The way to align your data to. Not everything is as flexible as

--- a/lib/cmock_generator.rb
+++ b/lib/cmock_generator.rb
@@ -57,9 +57,7 @@ class CMockGenerator
   private if $ThisIsOnlyATest.nil? ##############################
 
   def create_mock_subdir()
-    if @subdir
-      @file_writer.create_subdir(@subdir)
-    end
+    @file_writer.create_subdir(@subdir)
   end
 
   def create_mock_header_file(parsed_stuff)

--- a/src/cmock.c
+++ b/src/cmock.c
@@ -10,7 +10,7 @@
 //public constants to be used by mocks
 const char* CMockStringOutOfMemory = "CMock has run out of memory. Please allocate more.";
 const char* CMockStringCalledMore  = "Called more times than expected.";
-const char* CMockStringCalledLess  = "Called less times than expected.";
+const char* CMockStringCalledLess  = "Called fewer times than expected.";
 const char* CMockStringCalledEarly = "Called earlier than expected.";
 const char* CMockStringCalledLate  = "Called later than expected.";
 const char* CMockStringCallOrder   = "Called out of order.";

--- a/test/system/test_interactions/enforce_strict_ordering.yml
+++ b/test/system/test_interactions/enforce_strict_ordering.yml
@@ -100,7 +100,7 @@
 
     - :pass: FALSE
       :should: 'fail because bar() is called twice but is expected once'
-      :verify_error: 'Called less times than expected'
+      :verify_error: 'Called fewer times than expected'
       :code: |
         test()
         {

--- a/test/system/test_interactions/expect_any_args.yml
+++ b/test/system/test_interactions/expect_any_args.yml
@@ -66,7 +66,7 @@
         }
 
     - :pass: FALSE
-      :should: 'ignore foo() call details and notice if we called foo() less times than expected'
+      :should: 'ignore foo() call details and notice if we called foo() fewer times than expected'
       :code: |
         test()
         {


### PR DESCRIPTION
If the folder mocks doesn't exist then the following error occurs:
```
Creating mock for emg...
Traceback (most recent call last):
        9: from cmock/lib/cmock.rb:85:in `<main>'
        8: from cmock/lib/cmock.rb:30:in `setup_mocks'
        7: from cmock/lib/cmock.rb:30:in `each'
        6: from cmock/lib/cmock.rb:31:in `block in setup_mocks'
        5: from cmock/lib/cmock.rb:40:in `generate_mock'
        4: from /mnt/c/tests/cmock/lib/cmock_generator.rb:55:in `create_mock'
        3: from /mnt/c/tests/cmock/lib/cmock_generator.rb:69:in `create_mock_header_file'
        2: from /mnt/c/tests/cmock/lib/cmock_file_writer.rb:31:in `create_file'
        1: from /mnt/c/tests/cmock/lib/cmock_file_writer.rb:31:in `open'
/mnt/c/tests/cmock/lib/cmock_file_writer.rb:31:in `initialize': No such file or directory @ rb_sysopen - mocks/Mockemg.h.new (Errno::ENOENT)
```

This appears to be because it won't create the subdirectory which defaults by default to `mocks`

Removing this check should be safe as create_subdir() in cmock_file_writer.rb checks to see if the path directory tree exists before creating any necessary folders