### PR TITLE
Grammar fix--"fewer times", not "less times"

### DIFF
--- a/docs/CMock_Summary.md
+++ b/docs/CMock_Summary.md
@@ -153,7 +153,7 @@ only needs to be called once per test. It will then ignore any further calls to 
 particular mock. The IgnoreAndReturn works similarly, except that it has the added
 benefit of knowing what to return when that call happens. If the mock is called more
 times than IgnoreAndReturn was called, it will keep returning the last value without
-complaint. If it's called less times, it will also ignore that. You SAID you didn't
+complaint. If it's called fewer times, it will also ignore that. You SAID you didn't
 care how many times it was called, right?
 
 * `void func(void)` => `void func_Ignore(void)`
@@ -574,7 +574,7 @@ based on other settings, particularly Unity's settings.
 * `CMOCK_MEM_SIZE`
   In static mode this is the total amount of memory you are allocating
   to Cmock. In Dynamic mode this is the size of each chunk allocated
-  at once (larger numbers grab more memory but require less mallocs).
+  at once (larger numbers grab more memory but require fewer mallocs).
 
 * `CMOCK_MEM_ALIGN`
   The way to align your data to. Not everything is as flexible as

--- a/src/cmock.c
+++ b/src/cmock.c
@@ -10,7 +10,7 @@
 //public constants to be used by mocks
 const char* CMockStringOutOfMemory = "CMock has run out of memory. Please allocate more.";
 const char* CMockStringCalledMore  = "Called more times than expected.";
-const char* CMockStringCalledLess  = "Called less times than expected.";
+const char* CMockStringCalledLess  = "Called fewer times than expected.";
 const char* CMockStringCalledEarly = "Called earlier than expected.";
 const char* CMockStringCalledLate  = "Called later than expected.";
 const char* CMockStringCallOrder   = "Called out of order.";

--- a/test/system/test_interactions/enforce_strict_ordering.yml
+++ b/test/system/test_interactions/enforce_strict_ordering.yml
@@ -100,7 +100,7 @@
 
     - :pass: FALSE
       :should: 'fail because bar() is called twice but is expected once'
-      :verify_error: 'Called less times than expected'
+      :verify_error: 'Called fewer times than expected'
       :code: |
         test()
         {

--- a/test/system/test_interactions/expect_any_args.yml
+++ b/test/system/test_interactions/expect_any_args.yml
@@ -66,7 +66,7 @@
         }
 
     - :pass: FALSE
-      :should: 'ignore foo() call details and notice if we called foo() less times than expected'
+      :should: 'ignore foo() call details and notice if we called foo() fewer times than expected'
       :code: |
         test()
         {


### PR DESCRIPTION
Address https://github.com/ThrowTheSwitch/CMock/issues/156.

I didn't change the variable name `CMockStringCalledLess` since "called less than expected" (without a "times" or count) would still be correct grammar. (I don't suggest outputting that phrasing though, since it would probably be less clear.)