### PR TITLE
Adjusted travis to use ruby 2.3 to make OSX build pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,9 @@ os:
   - linux
 
 rvm:
-  - "2.2.2"
+  - "2.3"
 
 before_install:
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then rvm install 2.1 && rvm use 2.1 && ruby -v; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install --assume-yes --quiet gcc-multilib; fi
 
 install:


### PR DESCRIPTION
This adjusts travis to point to ruby 2.3 since ruby 2.2 is EOL. This should cause travis jobs to pass again.