### PR TITLE
Fixed compiler error in case of 'const' expected data.

### DIFF
--- a/lib/cmock_generator_utils.rb
+++ b/lib/cmock_generator_utils.rb
@@ -73,7 +73,7 @@ class CMockGeneratorUtils
     if (arg[:ptr?] or @treat_as.include?(arg[:type]))
       "  #{dest} = #{arg[:name]};\n"
     else
-      "  memcpy(&#{dest}, &#{arg[:name]}, sizeof(#{arg[:type]}));\n"
+      "  memcpy((void*)&#{dest}, (void*)&#{arg[:name]}, sizeof(#{arg[:type]}));\n"
     end
   end
 


### PR DESCRIPTION
In case the type of expected data has a 'const' it will fail with a compiler error. To avoid this a cast here is necessary to void*.