### PR TITLE
Mocks should call UNITY_CLR_DETAILS() after callback

### DIFF
--- a/lib/cmock_generator_plugin_callback.rb
+++ b/lib/cmock_generator_plugin_callback.rb
@@ -57,9 +57,13 @@ class CMockGeneratorPluginCallback
   def mock_implementation_for_callbacks_without_arg_check(function)
     "  if (Mock.#{function[:name]}_CallbackFunctionPointer != NULL)\n  {\n" +
       if function[:return][:void?]
-        "    #{generate_call(function)};\n    return;\n  }\n"
+        "    #{generate_call(function)};\n" \
+        "    UNITY_CLR_DETAILS();\n" \
+        "    return;\n  }\n"
       else
-        "    return #{generate_call(function)};\n  }\n"
+        "    #{function[:return][:type]} ret = #{generate_call(function)};\n" \
+        "    UNITY_CLR_DETAILS();\n" \
+        "    return ret;\n  }\n"
       end
   end
 

--- a/test/unit/cmock_generator_plugin_callback_test.rb
+++ b/test/unit/cmock_generator_plugin_callback_test.rb
@@ -165,6 +165,7 @@ describe CMockGeneratorPluginCallback, "Verify CMockGeneratorPluginCallback Modu
     expected = ["  if (Mock.Apple_CallbackFunctionPointer != NULL)\n",
                 "  {\n",
                 "    Mock.Apple_CallbackFunctionPointer();\n",
+                "    UNITY_CLR_DETAILS();\n",
                 "    return;\n",
                 "  }\n"
                ].join
@@ -177,7 +178,9 @@ describe CMockGeneratorPluginCallback, "Verify CMockGeneratorPluginCallback Modu
     function = {:name => "Apple", :args => [], :args_string => "void", :return => test_return[:int]}
     expected = ["  if (Mock.Apple_CallbackFunctionPointer != NULL)\n",
                 "  {\n",
-                "    return Mock.Apple_CallbackFunctionPointer(Mock.Apple_CallbackCalls++);\n",
+                "    int ret = Mock.Apple_CallbackFunctionPointer(Mock.Apple_CallbackCalls++);\n",
+                "    UNITY_CLR_DETAILS();\n",
+                "    return ret;\n",
                 "  }\n"
                ].join
     returned = @cmock_generator_plugin_callback.mock_implementation_for_callbacks_without_arg_check(function)
@@ -193,6 +196,7 @@ describe CMockGeneratorPluginCallback, "Verify CMockGeneratorPluginCallback Modu
     expected = ["  if (Mock.Apple_CallbackFunctionPointer != NULL)\n",
                 "  {\n",
                 "    Mock.Apple_CallbackFunctionPointer(steak, flag, Mock.Apple_CallbackCalls++);\n",
+                "    UNITY_CLR_DETAILS();\n",
                 "    return;\n",
                 "  }\n"
                ].join
@@ -209,6 +213,7 @@ describe CMockGeneratorPluginCallback, "Verify CMockGeneratorPluginCallback Modu
     expected = ["  if (Mock.Apple_CallbackFunctionPointer != NULL)\n",
                 "  {\n",
                 "    Mock.Apple_CallbackFunctionPointer(steak, flag);\n",
+                "    UNITY_CLR_DETAILS();\n",
                 "    return;\n",
                 "  }\n"
                ].join
@@ -225,7 +230,9 @@ describe CMockGeneratorPluginCallback, "Verify CMockGeneratorPluginCallback Modu
                 :return => test_return[:int]}
     expected = ["  if (Mock.Apple_CallbackFunctionPointer != NULL)\n",
                 "  {\n",
-                "    return Mock.Apple_CallbackFunctionPointer(steak, flag, Mock.Apple_CallbackCalls++);\n",
+                "    int ret = Mock.Apple_CallbackFunctionPointer(steak, flag, Mock.Apple_CallbackCalls++);\n",
+                "    UNITY_CLR_DETAILS();\n",
+                "    return ret;\n",
                 "  }\n"
                ].join
     returned = @cmock_generator_plugin_callback.mock_implementation_for_callbacks_without_arg_check(function)


### PR DESCRIPTION
A test failure, when it occurs immediately after a mocked function that called a stub callback, will incorrectly print the name of the mocked function as context.  This is due to the generated mock neglecting to call UNITY_CLR_DETAILS() before returning.