### PR TITLE
callback's mock_destroy() is redundant.

### DIFF
--- a/lib/cmock_generator_plugin_callback.rb
+++ b/lib/cmock_generator_plugin_callback.rb
@@ -85,11 +85,6 @@ class CMockGeneratorPluginCallback
     lines << "  Mock.#{func_name}_CallbackFunctionPointer = Callback;\n}\n\n"
   end
 
-  def mock_destroy(function)
-    "  Mock.#{function[:name]}_CallbackFunctionPointer = NULL;\n" +
-    "  Mock.#{function[:name]}_CallbackCalls = 0;\n"
-  end
-
   def mock_verify(function)
     func_name = function[:name]
     "  if (Mock.#{func_name}_CallbackFunctionPointer != NULL)\n    call_instance = CMOCK_GUTS_NONE;\n"

--- a/test/unit/cmock_generator_plugin_callback_test.rb
+++ b/test/unit/cmock_generator_plugin_callback_test.rb
@@ -248,12 +248,4 @@ describe CMockGeneratorPluginCallback, "Verify CMockGeneratorPluginCallback Modu
     returned = @cmock_generator_plugin_callback.mock_interfaces(function)
     assert_equal(expected, returned)
   end
-
-  it "add mock destroy for functions" do
-    function = {:name => "Peach", :args => [], :return => test_return[:void] }
-    expected = "  Mock.Peach_CallbackFunctionPointer = NULL;\n" +
-               "  Mock.Peach_CallbackCalls = 0;\n"
-    returned = @cmock_generator_plugin_callback.mock_destroy(function)
-    assert_equal(expected, returned)
-  end
 end


### PR DESCRIPTION
create_mock_destroy_function() in cmock_generator.rb already clears
the entire mock to 0 (using memset) before call the plugin's
mock_destroy() function.  So mock_destroy() in the callback plugin
is doing work that was already done.