### PR TITLE
Expect plugin should call UNITY_SET/CLR_DETAILS in pairs.

### DIFF
--- a/lib/cmock_generator_plugin_expect.rb
+++ b/lib/cmock_generator_plugin_expect.rb
@@ -91,14 +91,14 @@ class CMockGeneratorPluginExpect
     lines << @utils.code_add_base_expectation(func_name)
     lines << @utils.code_call_argument_loader(function)
     lines << @utils.code_assign_argument_quickly("cmock_call_instance->ReturnVal", function[:return]) unless (function[:return][:void?])
-    lines << "  UNITY_CLR_DETAILS();\n"
     lines << "}\n\n"
   end
 
   def mock_verify(function)
     func_name = function[:name]
     "  UNITY_SET_DETAIL(CMockString_#{function[:name]});\n" +
-    "  UNITY_TEST_ASSERT(CMOCK_GUTS_NONE == call_instance, cmock_line, CMockStringCalledLess);\n"
+    "  UNITY_TEST_ASSERT(CMOCK_GUTS_NONE == call_instance, cmock_line, CMockStringCalledLess);\n" +
+    "  UNITY_CLR_DETAILS();\n"
   end
 
 end

--- a/test/unit/cmock_generator_plugin_expect_a_test.rb
+++ b/test/unit/cmock_generator_plugin_expect_a_test.rb
@@ -119,7 +119,6 @@ describe CMockGeneratorPluginExpect, "Verify CMockGeneratorPluginExpect Module W
                 "{\n",
                 "mock_retval_0 ",
                 "mock_retval_1 ",
-                "  UNITY_CLR_DETAILS();\n",
                 "}\n\n"
                ].join
     returned = @cmock_generator_plugin_expect.mock_interfaces(function)
@@ -136,7 +135,6 @@ describe CMockGeneratorPluginExpect, "Verify CMockGeneratorPluginExpect Module W
                 "mock_retval_0 ",
                 "mock_retval_1 ",
                 "mock_retval_2",
-                "  UNITY_CLR_DETAILS();\n",
                 "}\n\n"
                ].join
     returned = @cmock_generator_plugin_expect.mock_interfaces(function)
@@ -153,7 +151,6 @@ describe CMockGeneratorPluginExpect, "Verify CMockGeneratorPluginExpect Module W
                 "mock_retval_0 ",
                 "mock_retval_1 ",
                 "mock_retval_2",
-                "  UNITY_CLR_DETAILS();\n",
                 "}\n\n"
                ].join
     returned = @cmock_generator_plugin_expect.mock_interfaces(function)
@@ -168,7 +165,6 @@ describe CMockGeneratorPluginExpect, "Verify CMockGeneratorPluginExpect Module W
                 "{\n",
                 "mock_retval_0 ",
                 "mock_retval_1 ",
-                "  UNITY_CLR_DETAILS();\n",
                 "}\n\n"
                ].join
     @cmock_generator_plugin_expect.ordered = true
@@ -179,7 +175,8 @@ describe CMockGeneratorPluginExpect, "Verify CMockGeneratorPluginExpect Module W
   it "add mock verify lines" do
     function = {:name => "Banana" }
     expected = "  UNITY_SET_DETAIL(CMockString_Banana);\n" +
-               "  UNITY_TEST_ASSERT(CMOCK_GUTS_NONE == call_instance, cmock_line, CMockStringCalledLess);\n"
+               "  UNITY_TEST_ASSERT(CMOCK_GUTS_NONE == call_instance, cmock_line, CMockStringCalledLess);\n" +
+               "  UNITY_CLR_DETAILS();\n"
     returned = @cmock_generator_plugin_expect.mock_verify(function)
     assert_equal(expected, returned)
   end

--- a/test/unit/cmock_generator_plugin_expect_b_test.rb
+++ b/test/unit/cmock_generator_plugin_expect_b_test.rb
@@ -135,7 +135,6 @@ describe CMockGeneratorPluginExpect, "Verify CMockGeneratorPluginExpect Module w
                 "{\n",
                 "mock_retval_0\n",
                 "mock_retval_1\n",
-                "  UNITY_CLR_DETAILS();\n",
                 "}\n\n"
                ].join
     returned = @cmock_generator_plugin_expect.mock_interfaces(function)
@@ -152,7 +151,6 @@ describe CMockGeneratorPluginExpect, "Verify CMockGeneratorPluginExpect Module w
                 "mock_retval_0\n",
                 "mock_retval_1\n",
                 "mock_retval_2\n",
-                "  UNITY_CLR_DETAILS();\n",
                 "}\n\n"
                ].join
     returned = @cmock_generator_plugin_expect.mock_interfaces(function)
@@ -169,7 +167,6 @@ describe CMockGeneratorPluginExpect, "Verify CMockGeneratorPluginExpect Module w
                 "mock_retval_0\n",
                 "mock_retval_1\n",
                 "mock_retval_2\n",
-                "  UNITY_CLR_DETAILS();\n",
                 "}\n\n"
                ].join
     returned = @cmock_generator_plugin_expect.mock_interfaces(function)
@@ -184,7 +181,6 @@ describe CMockGeneratorPluginExpect, "Verify CMockGeneratorPluginExpect Module w
                 "{\n",
                 "mock_retval_0\n",
                 "mock_retval_1\n",
-                "  UNITY_CLR_DETAILS();\n",
                 "}\n\n"
                ].join
     @cmock_generator_plugin_expect.ordered = true
@@ -195,7 +191,8 @@ describe CMockGeneratorPluginExpect, "Verify CMockGeneratorPluginExpect Module w
   it "add mock verify lines" do
     function = {:name => "Banana" }
     expected = "  UNITY_SET_DETAIL(CMockString_Banana);\n" +
-               "  UNITY_TEST_ASSERT(CMOCK_GUTS_NONE == call_instance, cmock_line, CMockStringCalledLess);\n"
+               "  UNITY_TEST_ASSERT(CMOCK_GUTS_NONE == call_instance, cmock_line, CMockStringCalledLess);\n" +
+               "  UNITY_CLR_DETAILS();\n"
     returned = @cmock_generator_plugin_expect.mock_verify(function)
     assert_equal(expected, returned)
   end


### PR DESCRIPTION
The generated _Expect() functions called UNITY_CLR_DETAILS, which was unnecessary because they did not call UNITY_SET_DETAIL.

The generated _Verify() functions called UNITY_SET_DETAIL but never called UNITY_CLR_DETAILS to clean up after themselves.