### PR TITLE
Replace IgnoreMode with ExpectAnyArgsBool (no functional change).

### DIFF
--- a/lib/cmock_generator_plugin_expect.rb
+++ b/lib/cmock_generator_plugin_expect.rb
@@ -64,7 +64,7 @@ class CMockGeneratorPluginExpect
 
   def mock_implementation_might_check_args(function)
     return "" if (function[:args].empty?)
-    lines = "  if (cmock_call_instance->IgnoreMode != CMOCK_ARG_NONE)\n  {\n"
+    lines = "  if (!cmock_call_instance->ExpectAnyArgsBool)\n  {\n"
     function[:args].each do |arg|
       lines << @utils.code_verify_an_arg_expectation(function, arg)
     end

--- a/lib/cmock_generator_plugin_expect_any_args.rb
+++ b/lib/cmock_generator_plugin_expect_any_args.rb
@@ -15,16 +15,8 @@ class CMockGeneratorPluginExpectAnyArgs
     @priority = 3
   end
 
-  def instance_structure(function)
-    if (function[:return][:void?]) || (@config.plugins.include? :ignore)
-      ""
-    else
-      "  #{function[:return][:type]} #{function[:name]}_FinalReturn;\n"
-    end
-  end
-
   def instance_typedefs(function)
-    "  CMOCK_ARG_MODE IgnoreMode;\n"
+    "  int ExpectAnyArgsBool;\n"
   end
 
   def mock_function_declarations(function)
@@ -48,7 +40,7 @@ class CMockGeneratorPluginExpectAnyArgs
     unless (function[:return][:void?])
       lines << "  cmock_call_instance->ReturnVal = cmock_to_return;\n"
     end
-    lines << "  cmock_call_instance->IgnoreMode = CMOCK_ARG_NONE;\n"
+    lines << "  cmock_call_instance->ExpectAnyArgsBool = (int)1;\n"
     lines << "}\n\n"
   end
 end

--- a/lib/cmock_generator_utils.rb
+++ b/lib/cmock_generator_utils.rb
@@ -57,7 +57,7 @@ class CMockGeneratorUtils
     lines << "  cmock_call_instance->LineNumber = cmock_line;\n"
     lines << "  cmock_call_instance->CallOrder = ++GlobalExpectCount;\n" if (@ordered and global_ordering_supported)
     lines << "  cmock_call_instance->ExceptionToThrow = CEXCEPTION_NONE;\n" if (@cexception)
-    lines << "  cmock_call_instance->IgnoreMode = CMOCK_ARG_ALL;\n" if (@expect_any)
+    lines << "  cmock_call_instance->ExpectAnyArgsBool = (int)0;\n" if (@expect_any)
     lines
   end
 

--- a/src/cmock.h
+++ b/src/cmock.h
@@ -16,10 +16,6 @@
 
 #define CMOCK_GUTS_NONE   (0)
 
-#define CMOCK_ARG_MODE    CMOCK_MEM_INDEX_TYPE
-#define CMOCK_ARG_ALL     0
-#define CMOCK_ARG_NONE    ((CMOCK_MEM_INDEX_TYPE)(~0U))
-
 //-------------------------------------------------------
 // Memory API
 //-------------------------------------------------------

--- a/test/unit/cmock_generator_plugin_expect_any_args_test.rb
+++ b/test/unit/cmock_generator_plugin_expect_any_args_test.rb
@@ -50,7 +50,7 @@ describe CMockGeneratorPluginExpectAnyArgs, "Verify CMockGeneratorPluginExpectAn
     expected = ["void Slime_CMockExpectAnyArgs(UNITY_LINE_TYPE cmock_line)\n",
                 "{\n",
                 "mock_return_1",
-                "  cmock_call_instance->IgnoreMode = CMOCK_ARG_NONE;\n",
+                "  cmock_call_instance->ExpectAnyArgsBool = (int)1;\n",
                 "}\n\n"
                ].join
     @utils.expect :code_add_base_expectation, "mock_return_1", ["Slime", true]

--- a/test/unit/cmock_generator_plugin_expect_b_test.rb
+++ b/test/unit/cmock_generator_plugin_expect_b_test.rb
@@ -98,7 +98,7 @@ describe CMockGeneratorPluginExpect, "Verify CMockGeneratorPluginExpect Module w
 
     @utils.expect :code_verify_an_arg_expectation, "mocked_retval_1\n", [function, function[:args][0]]
     @utils.expect :code_verify_an_arg_expectation, "mocked_retval_2\n", [function, function[:args][1]]
-    expected = "  if (cmock_call_instance->IgnoreMode != CMOCK_ARG_NONE)\n" +
+    expected = "  if (!cmock_call_instance->ExpectAnyArgsBool)\n" +
                "  {\n" +
                "mocked_retval_1\n" +
                "mocked_retval_2\n" +
@@ -118,7 +118,7 @@ describe CMockGeneratorPluginExpect, "Verify CMockGeneratorPluginExpect Module w
   it "add mock function implementation for functions of style 'void func(int worm)' and strict ordering" do
     function = {:name => "Apple", :args => [{ :type => "int", :name => "worm" }], :return => test_return[:void]}
     @utils.expect :code_verify_an_arg_expectation, "mocked_retval_0\n", [function, function[:args][0]]
-    expected = "  if (cmock_call_instance->IgnoreMode != CMOCK_ARG_NONE)\n" +
+    expected = "  if (!cmock_call_instance->ExpectAnyArgsBool)\n" +
                "  {\n" +
                "mocked_retval_0\n" +
                "  }\n"


### PR DESCRIPTION
IgnoreMode was used only for the ExpectAnyArgs plugin, and the
semantics of it were backwards:

  - IgnoreMode = CMOCK_ARG_NONE means to ignore all arguments
  - IgnoreMode = CMOCK_ARG_ALL means to verify all arguments

ExpectAnyArgsBool should make the purpose and semantics of this
field clearer.

Additionally, ExpectAnyArgs doesn't use FinalReturn for anything.