### PR TITLE
Add source directory subdirectory support to CMock

### DIFF
--- a/lib/cmock.rb
+++ b/lib/cmock.rb
@@ -23,7 +23,6 @@ class CMock
     cm_gen_plugins = CMockPluginManager.new(cm_config, cm_gen_utils)
     @cm_parser     = CMockHeaderParser.new(cm_config)
     @cm_generator  = CMockGenerator.new(cm_config, cm_writer, cm_gen_utils, cm_gen_plugins)
-    @silent        = (cm_config.verbosity < 2)
   end
 
   def setup_mocks(files)
@@ -36,8 +35,7 @@ class CMock
 
   def generate_mock(src)
     name = File.basename(src, '.h')
-    puts "Creating mock for #{name}..." unless @silent
-    @cm_generator.create_mock(name, @cm_parser.parse(name, File.read(src)))
+    @cm_generator.create_mock(src, @cm_parser.parse(name, File.read(src)))
   end
 end
 

--- a/lib/cmock_config.rb
+++ b/lib/cmock_config.rb
@@ -14,6 +14,7 @@ class CMockConfig
     :mock_suffix                 => '',
     :weak                        => '',
     :subdir                      => nil,
+    :srcdir                      => nil,
     :plugins                     => [],
     :strippables                 => ['(?:__attribute__\s*\(+.*?\)+)'],
     :attributes                  => ['__ramfunc', '__irq', '__fiq', 'register', 'extern'],

--- a/scripts/create_makefile.rb
+++ b/scripts/create_makefile.rb
@@ -39,7 +39,7 @@ File.open(TEST_MAKEFILE, "w") do |mkfile|
   mkfile.puts "BUILD_DIR = #{BUILD_DIR}"
   mkfile.puts "SRC_DIR = #{SRC_DIR}"
   mkfile.puts "TEST_DIR = #{TEST_DIR}"
-  mkfile.puts "TEST_CFLAGS ?= -DTEST"
+  mkfile.puts "TEST_CFLAGS ?= ${CFLAGS} -DTEST"
   mkfile.puts "CMOCK_DIR ?= #{CMOCK_DIR}"
   mkfile.puts "CMOCK_CONFIG ?= #{CMOCK_CONFIG}"
   mkfile.puts "UNITY_DIR ?= #{UNITY_DIR}"
@@ -52,12 +52,12 @@ File.open(TEST_MAKEFILE, "w") do |mkfile|
 
   # Build Unity
   mkfile.puts "#{UNITY_OBJ}: #{UNITY_SRC}/unity.c"
-  mkfile.puts "\t${CC} -o $@ -c $< -I #{UNITY_SRC}"
+  mkfile.puts "\t${CC} -o $@ -c $< -I #{UNITY_SRC} ${CFLAGS}"
   mkfile.puts ""
 
   # Build CMock
   mkfile.puts "#{CMOCK_OBJ}: #{CMOCK_SRC}/cmock.c"
-  mkfile.puts "\t${CC} -o $@ -c $< -I #{UNITY_SRC} -I #{CMOCK_SRC}"
+  mkfile.puts "\t${CC} -o $@ -c $< -I #{UNITY_SRC} -I #{CMOCK_SRC} ${CFLAGS}"
   mkfile.puts ""
 
   test_sources = Dir["#{TEST_DIR}/**/test_*.c"]

--- a/scripts/create_makefile.rb
+++ b/scripts/create_makefile.rb
@@ -41,6 +41,7 @@ File.open(TEST_MAKEFILE, "w") do |mkfile|
   mkfile.puts "CMOCK_DIR ?= #{CMOCK_DIR}"
   mkfile.puts "UNITY_DIR ?= #{UNITY_DIR}"
   mkfile.puts "TEST_BUILD_DIR ?= ${BUILD_DIR}/test"
+  mkfile.puts "MOCKS_DIR ?= ${TEST_BUILD_DIR}/mocks"
   mkfile.puts "TEST_MAKEFILE = ${TEST_BUILD_DIR}/MakefileTestSupport"
   mkfile.puts "OBJ ?= ${BUILD_DIR}/obj"
   mkfile.puts "OBJ_DIR = ${OBJ}"
@@ -180,7 +181,7 @@ File.open(TEST_MAKEFILE, "w") do |mkfile|
     mock_obj = File.join(MOCKS_DIR, mock_name + '.o')
 
     mkfile.puts "#{mock_src}: #{hdr}"
-    mkfile.puts "\t@CMOCK_DIR=${CMOCK_DIR} ruby ${CMOCK_DIR}/scripts/create_mock.rb #{hdr}"
+    mkfile.puts "\t@CMOCK_DIR=${CMOCK_DIR} MOCKS_DIR=${MOCKS_DIR} ruby ${CMOCK_DIR}/scripts/create_mock.rb #{hdr}"
     mkfile.puts ""
 
     mkfile.puts "#{mock_obj}: #{mock_src} #{mock_header}"

--- a/scripts/create_makefile.rb
+++ b/scripts/create_makefile.rb
@@ -15,6 +15,7 @@ TEST_BUILD_DIR = ENV.fetch('TEST_BUILD_DIR', File.join(BUILD_DIR, 'test'))
 OBJ_DIR = File.join(TEST_BUILD_DIR, 'obj')
 UNITY_OBJ = File.join(OBJ_DIR, 'unity.o')
 CMOCK_OBJ = File.join(OBJ_DIR, 'cmock.o')
+CMOCK_CONFIG = ENV.fetch('CMOCK_CONFIG', '')
 RUNNERS_DIR = File.join(TEST_BUILD_DIR, 'runners')
 MOCKS_DIR = File.join(TEST_BUILD_DIR, 'mocks')
 TEST_BIN_DIR = TEST_BUILD_DIR
@@ -40,6 +41,7 @@ File.open(TEST_MAKEFILE, "w") do |mkfile|
   mkfile.puts "TEST_DIR = #{TEST_DIR}"
   mkfile.puts "TEST_CFLAGS ?= -DTEST"
   mkfile.puts "CMOCK_DIR ?= #{CMOCK_DIR}"
+  mkfile.puts "CMOCK_CONFIG ?= #{CMOCK_CONFIG}"
   mkfile.puts "UNITY_DIR ?= #{UNITY_DIR}"
   mkfile.puts "TEST_BUILD_DIR ?= ${BUILD_DIR}/test"
   mkfile.puts "MOCKS_DIR ?= ${TEST_BUILD_DIR}/mocks"
@@ -185,7 +187,7 @@ File.open(TEST_MAKEFILE, "w") do |mkfile|
     mock_obj = File.join(MOCKS_DIR, File.join(src_hdr_directory, mock_name + '.o'))
 
     mkfile.puts "#{mock_src}: #{hdr}"
-    mkfile.puts "\t@CMOCK_DIR=${CMOCK_DIR} MOCKS_DIR=${MOCKS_DIR} ruby ${CMOCK_DIR}/scripts/create_mock.rb #{hdr}"
+    mkfile.puts "\t@CMOCK_DIR=${CMOCK_DIR} CMOCK_CONFIG=${CMOCK_CONFIG} MOCKS_DIR=${MOCKS_DIR} ruby ${CMOCK_DIR}/scripts/create_mock.rb #{hdr}"
     mkfile.puts ""
 
     mkfile.puts "#{mock_obj}: #{mock_src} #{mock_header}"

--- a/scripts/create_mock.rb
+++ b/scripts/create_mock.rb
@@ -4,5 +4,6 @@ raise "Header file to mock must be specified!" unless ARGV.length >= 1
 
 mock_out = ENV.fetch('MOCKS_DIR', './build/test/mocks')
 mock_prefix = ENV.fetch('MOCK_PREFIX', 'mock_')
-cmock = CMock.new({:plugins => [:ignore, :return_thru_ptr], :mock_prefix => mock_prefix, :mock_path => mock_out})
+srcdir =  ENV.fetch("SRC_DIR", nil)
+cmock = CMock.new({:plugins => [:ignore, :return_thru_ptr], :mock_prefix => mock_prefix, :mock_path => mock_out, :srcdir => srcdir})
 cmock.setup_mocks(ARGV[0])

--- a/scripts/create_mock.rb
+++ b/scripts/create_mock.rb
@@ -4,6 +4,6 @@ raise "Header file to mock must be specified!" unless ARGV.length >= 1
 
 mock_out = ENV.fetch('MOCKS_DIR', './build/test/mocks')
 mock_prefix = ENV.fetch('MOCK_PREFIX', 'mock_')
-srcdir =  ENV.fetch("SRC_DIR", nil)
-cmock = CMock.new({:plugins => [:ignore, :return_thru_ptr], :mock_prefix => mock_prefix, :mock_path => mock_out, :srcdir => srcdir})
+cmock_config = ENV.fetch('CMOCK_CONFIG', {:plugins => [:ignore, :return_thru_ptr], :mock_prefix => mock_prefix, :mock_path => mock_out})
+cmock = CMock.new(cmock_config)
 cmock.setup_mocks(ARGV[0])

--- a/scripts/create_mock.rb
+++ b/scripts/create_mock.rb
@@ -2,7 +2,7 @@ require "#{ENV['CMOCK_DIR']}/lib/cmock"
 
 raise "Header file to mock must be specified!" unless ARGV.length >= 1
 
-mock_out = ENV.fetch('MOCK_OUT', './build/test/mocks')
+mock_out = ENV.fetch('MOCKS_DIR', './build/test/mocks')
 mock_prefix = ENV.fetch('MOCK_PREFIX', 'mock_')
 cmock = CMock.new({:plugins => [:ignore, :return_thru_ptr], :mock_prefix => mock_prefix, :mock_path => mock_out})
 cmock.setup_mocks(ARGV[0])

--- a/scripts/create_mock.rb
+++ b/scripts/create_mock.rb
@@ -4,6 +4,11 @@ raise "Header file to mock must be specified!" unless ARGV.length >= 1
 
 mock_out = ENV.fetch('MOCKS_DIR', './build/test/mocks')
 mock_prefix = ENV.fetch('MOCK_PREFIX', 'mock_')
-cmock_config = ENV.fetch('CMOCK_CONFIG', {:plugins => [:ignore, :return_thru_ptr], :mock_prefix => mock_prefix, :mock_path => mock_out})
+
+cmock_config = ENV.fetch('CMOCK_CONFIG', "")
+if cmock_config.empty?
+  cmock_config = {:plugins => [:ignore, :return_thru_ptr], :mock_prefix => mock_prefix, :mock_path => mock_out}
+end
+
 cmock = CMock.new(cmock_config)
 cmock.setup_mocks(ARGV[0])

--- a/test/unit/cmock_generator_main_test.rb
+++ b/test/unit/cmock_generator_main_test.rb
@@ -53,6 +53,8 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
     @config.expect :includes_c_pre_header, nil
     @config.expect :includes_c_post_header, nil
     @config.expect :subdir, nil
+    @config.expect :srcdir, nil
+    @config.expect :verbosity, 1
     @config.expect :fail_on_unexpected_calls, true
     @cmock_generator = CMockGenerator.new(@config, @file_writer, @utils, @plugins)
     @cmock_generator.module_name = @module_name
@@ -71,6 +73,8 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
     @config.expect :includes_c_pre_header, nil
     @config.expect :includes_c_post_header, nil
     @config.expect :subdir, nil
+    @config.expect :srcdir, nil
+    @config.expect :verbosity, 1
     @config.expect :fail_on_unexpected_calls, true
     @cmock_generator_strict = CMockGenerator.new(@config, @file_writer, @utils, @plugins)
     @cmock_generator_strict.module_name = @module_name
@@ -132,6 +136,8 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
     @config.expect :includes_c_pre_header, nil
     @config.expect :includes_c_post_header, nil
     @config.expect :subdir, nil
+    @config.expect :srcdir, nil
+    @config.expect :verbosity, 1
     @config.expect :fail_on_unexpected_calls, true
     @cmock_generator2 = CMockGenerator.new(@config, @file_writer, @utils, @plugins)
     @cmock_generator2.module_name = "Pout-Pout Fish"


### PR DESCRIPTION
## Problem

While using the CMock `create_makefile.rb` script to generate mocks and unit tests, I encountered the problem that the script did not support a more complicated directory structure. Consider the following directory stucture:

```
src
├── drv
│   ├── button_driver.c
│   ├── button_driver.h
│   ├── led_driver.c
│   ├── led_driver.h
│   ├── watchdog_driver.c
│   └── watchdog_driver.h
├── main.c
└── protocol
    ├── uart_tlv.c
    └── uart_tlv.h

test
├── protocol
│   └── test_uart_tlv.c
├── drv
│   ├── test_button_driver.c
│   ├── test_led_driver.c
│   └── test_watchdog_driver.c
└── test_eventloop.c
```

Using the provided script as used in the make_example fails due to the cmock_generator removing the source directory subdirectories.

## Solution
This pull request fixes:

* 3e83c9a: A custom mock_path was not passed along to the CMock config
* 5d64113: Pass the full source path to `cmock_generator.rb` so the relative source directory can be determined. Change the makefile generation so mocks in subdirectories are supported.
* 9f9345e: Add the possibility of providing a custom config instead of using the hardcoded one.
* 2d5ec03: use project wide CFLAGS to the generated makefile
* 56515a2: fix mistake with the empty CMOCK_CONFIG environment variable

## Potential regressions

Projects sorting their test files in a different structure than the source directory structure will break.


--
I have not written any Ruby before, so any remarks on this pull requests are very welcome.