### PR TITLE
Fix minor memory-management bugs

### DIFF
--- a/src/cmock.c
+++ b/src/cmock.c
@@ -4,7 +4,6 @@
     [Released under MIT License. Please refer to license.txt for details]
 ========================================== */
 
-#include "unity.h"
 #include "cmock.h"
 
 //public constants to be used by mocks

--- a/src/cmock.c
+++ b/src/cmock.c
@@ -23,11 +23,11 @@ const char* CMockStringMismatch    = "Function called with unexpected argument v
 #ifdef CMOCK_MEM_DYNAMIC
 static unsigned char*         CMock_Guts_Buffer = NULL;
 static CMOCK_MEM_INDEX_TYPE   CMock_Guts_BufferSize = CMOCK_MEM_ALIGN_SIZE;
-static CMOCK_MEM_INDEX_TYPE   CMock_Guts_FreePtr;
+static CMOCK_MEM_INDEX_TYPE   CMock_Guts_FreePtr = CMOCK_MEM_ALIGN_SIZE;
 #else
 static unsigned char          CMock_Guts_Buffer[CMOCK_MEM_SIZE + CMOCK_MEM_ALIGN_SIZE];
 static CMOCK_MEM_INDEX_TYPE   CMock_Guts_BufferSize = CMOCK_MEM_SIZE + CMOCK_MEM_ALIGN_SIZE;
-static CMOCK_MEM_INDEX_TYPE   CMock_Guts_FreePtr;
+static CMOCK_MEM_INDEX_TYPE   CMock_Guts_FreePtr = CMOCK_MEM_ALIGN_SIZE;
 #endif
 
 //-------------------------------------------------------

--- a/src/cmock.c
+++ b/src/cmock.c
@@ -45,7 +45,7 @@ CMOCK_MEM_INDEX_TYPE CMock_Guts_MemNew(CMOCK_MEM_INDEX_TYPE size)
   size = size + CMOCK_MEM_INDEX_SIZE;
   if (size & CMOCK_MEM_ALIGN_MASK)
     size = (size + CMOCK_MEM_ALIGN_MASK) & ~CMOCK_MEM_ALIGN_MASK;
-  if ((CMock_Guts_BufferSize - CMock_Guts_FreePtr) <= size)
+  if ((CMock_Guts_BufferSize - CMock_Guts_FreePtr) < size)
   {
 #ifndef CMOCK_MEM_DYNAMIC
     return CMOCK_GUTS_NONE; // nothing we can do; our static buffer is out of memory

--- a/src/cmock_internals.h
+++ b/src/cmock_internals.h
@@ -7,6 +7,8 @@
 #ifndef CMOCK_FRAMEWORK_INTERNALS_H
 #define CMOCK_FRAMEWORK_INTERNALS_H
 
+#include "unity.h"
+
 //These are constants that the generated mocks have access to
 extern const char* CMockStringOutOfMemory;
 extern const char* CMockStringCalledMore;


### PR DESCRIPTION
Test case:

```
#include "cmock.h"
#include <assert.h>
#include <stdio.h>

int main(void)
{
    printf("%d-byte alignment\n", CMOCK_MEM_ALIGN_SIZE);
    printf("%d bytes capacity\n", CMock_Guts_MemBytesCapacity());
    printf("%d bytes used\n", CMock_Guts_MemBytesUsed());
    printf("%d bytes free\n", CMock_Guts_MemBytesFree());

    CMOCK_MEM_INDEX_TYPE bytes = CMock_Guts_MemBytesFree() - CMOCK_MEM_INDEX_SIZE;
    CMOCK_MEM_INDEX_TYPE alloc = CMock_Guts_MemNew(bytes);
    assert(alloc != CMOCK_GUTS_NONE);

    printf("Allocated %d bytes\n", bytes);
    printf("%d bytes used\n", CMock_Guts_MemBytesUsed());
    printf("%d bytes free\n", CMock_Guts_MemBytesFree());

    return 0;
}
```

Expected output:

```
8-byte alignment
32768 bytes capacity
0 bytes used
32768 bytes free
Allocated 32760 bytes
32768 bytes used
0 bytes free
```