### PR TITLE
make ret variable more unique to prevent collision with with code under test

### DIFF
--- a/lib/cmock_generator_plugin_callback.rb
+++ b/lib/cmock_generator_plugin_callback.rb
@@ -60,9 +60,9 @@ class CMockGeneratorPluginCallback
         "    UNITY_CLR_DETAILS();\n" \
         "    return;\n  }\n"
       else
-        "    #{function[:return][:type]} ret = #{generate_call(function)};\n" \
+        "    #{function[:return][:type]} cmock_cb_ret = #{generate_call(function)};\n" \
         "    UNITY_CLR_DETAILS();\n" \
-        "    return ret;\n  }\n"
+        "    return cmock_cb_ret;\n  }\n"
       end
   end
 

--- a/test/unit/cmock_generator_plugin_callback_test.rb
+++ b/test/unit/cmock_generator_plugin_callback_test.rb
@@ -191,9 +191,9 @@ describe CMockGeneratorPluginCallback, "Verify CMockGeneratorPluginCallback Modu
     expected = ["  if (!Mock.Apple_CallbackBool &&\n",
                 "      Mock.Apple_CallbackFunctionPointer != NULL)\n",
                 "  {\n",
-                "    int ret = Mock.Apple_CallbackFunctionPointer(Mock.Apple_CallbackCalls++);\n",
+                "    int cmock_cb_ret = Mock.Apple_CallbackFunctionPointer(Mock.Apple_CallbackCalls++);\n",
                 "    UNITY_CLR_DETAILS();\n",
-                "    return ret;\n",
+                "    return cmock_cb_ret;\n",
                 "  }\n"
                ].join
     returned = @cmock_generator_plugin_callback.mock_implementation_precheck(function)
@@ -246,9 +246,9 @@ describe CMockGeneratorPluginCallback, "Verify CMockGeneratorPluginCallback Modu
     expected = ["  if (!Mock.Apple_CallbackBool &&\n",
                 "      Mock.Apple_CallbackFunctionPointer != NULL)\n",
                 "  {\n",
-                "    int ret = Mock.Apple_CallbackFunctionPointer(steak, flag, Mock.Apple_CallbackCalls++);\n",
+                "    int cmock_cb_ret = Mock.Apple_CallbackFunctionPointer(steak, flag, Mock.Apple_CallbackCalls++);\n",
                 "    UNITY_CLR_DETAILS();\n",
-                "    return ret;\n",
+                "    return cmock_cb_ret;\n",
                 "  }\n"
                ].join
     returned = @cmock_generator_plugin_callback.mock_implementation_precheck(function)


### PR DESCRIPTION
This is a small change in the callback plugin to rename the ret variable from a callback to less conflict with end users code. If a function has ret as a variable name as is sometimes done when returning thru a pointer best case a warning is generate, but most likely causes compiler errors.