### PR TITLE
Inline function mocking refactor

### DIFF
--- a/lib/cmock_header_parser.rb
+++ b/lib/cmock_header_parser.rb
@@ -78,12 +78,12 @@ class CMockHeaderParser
   def count_number_of_pairs_of_braces_in_function(source)
     is_function_start_found = false
     curr_level = 0
-    total_levels = 0
+    total_pairs = 0
 
     source.each_char do |c|
       if ("{" == c)
         curr_level += 1
-        total_levels  +=1
+        total_pairs  +=1
         is_function_start_found = true
       elsif ("}" == c)
         curr_level -=1
@@ -93,10 +93,10 @@ class CMockHeaderParser
     end
 
     if 0 != curr_level
-      total_levels = 0          # Something is fishy about this source, not enough closing braces?
+      total_pairs = 0          # Something is fishy about this source, not enough closing braces?
     end
 
-    return total_levels
+    return total_pairs
   end
 
   # Transform inline functions to regular functions in the source by the user

--- a/lib/cmock_header_parser.rb
+++ b/lib/cmock_header_parser.rb
@@ -139,9 +139,9 @@ class CMockHeaderParser
         break if 0 == total_pairs_to_remove # Bad source?
 
         inline_function_stripped = inline_function_match.post_match
-        until total_pairs_to_remove == 0
+
+        total_pairs_to_remove.times do
           inline_function_stripped.sub!(/\s*#{square_bracket_pair_regex_format}/, ";") # Remove inline implementation (+ some whitespace because it's prettier)
-          total_pairs_to_remove -= 1
         end
 
         source = inline_function_match.pre_match + inline_function_stripped # Make new source with the inline function removed and move on to the next

--- a/lib/cmock_header_parser.rb
+++ b/lib/cmock_header_parser.rb
@@ -108,7 +108,7 @@ class CMockHeaderParser
     # - sometimes they appear together, sometimes individually,
     # - The keywords can appear before or after the return type (this is a compiler warning but people do weird stuff),
     #   so we check for word boundaries when searching for them
-    # - We first remove "static inline" combinations and boil down to
+    # - We first remove "static inline" combinations and boil down to single inline or static statements
     inline_function_regex_formats = [
       /(static\s+inline|inline\s+static)\s*/,        # Last part (\s*) is just to remove whitespaces (only to prettify the output)
       /(\bstatic\b|\binline\b)\s*/,                  # Last part (\s*) is just to remove whitespaces (only to prettify the output)
@@ -140,7 +140,7 @@ class CMockHeaderParser
 
         inline_function_stripped = inline_function_match.post_match
         until total_pairs_to_remove == 0
-          inline_function_stripped.sub!(/\s*#{square_bracket_pair_regex_format}/, ";") # Remove inline implementation
+          inline_function_stripped.sub!(/\s*#{square_bracket_pair_regex_format}/, ";") # Remove inline implementation (+ some whitespace because it's prettier)
           total_pairs_to_remove -= 1
         end
 

--- a/test/system/test_compilation/inline.h
+++ b/test/system/test_compilation/inline.h
@@ -1,19 +1,19 @@
 
-static inline void dummy_func_0(void) {
+static inline int dummy_func_0(void) {
 	return 5;
 }
 
-inline static void dummy_func_1(int a) {
+inline static int dummy_func_1(int a) {
 	int a = dummy_func_0();
 	int b = 10;
 
 	return a + b;
 }
 
-void inline static dummy_func_2(int a, char b, float c) {
+int inline static dummy_func_2(int a, char b, float c) {
 	c += 3.14;
 	b -= 32;
-	return a + (int)(b) + c;
+	return a + (int)(b) + (int)c;
 }
 
 void dummy_normal_func(int a);

--- a/test/unit/cmock_header_parser_test.rb
+++ b/test/unit/cmock_header_parser_test.rb
@@ -1988,9 +1988,13 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
       "\t}\n" +
       "\treturn 42;\n" +
       "}\n"
+    bad_source_2 =
+      "int foo(struct my_struct *s)\n" +
+      "\n"                      # No braces in source
 
     assert_equal(0, @parser.count_number_of_pairs_of_braces_in_function(bad_source_0))
     assert_equal(0, @parser.count_number_of_pairs_of_braces_in_function(bad_source_1))
+    assert_equal(0, @parser.count_number_of_pairs_of_braces_in_function(bad_source_2))
   end
 
 end

--- a/test/unit/cmock_header_parser_test.rb
+++ b/test/unit/cmock_header_parser_test.rb
@@ -1944,4 +1944,53 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
     assert_equal(expected, @parser.transform_inline_functions(source))
   end
 
+  it "Count number of pairs of braces in function succesfully" do
+    source =
+      "int foo(struct my_struct *s)\n" +
+      "{\n" +
+      "    return get_member_a(s) + 42;\n" +
+      "}\n"
+    complex_source =
+      "int bar(struct my_struct *s)\n" +
+      "{\n" +
+      "\tint a = 6;\n" +
+      "\tint res = foo(&(struct my_struct){.nr = a});\n" +
+      "\t{\n" +
+      "\t\tint a = 5;\n" +
+      "\t\tint res = foo(&(struct my_struct){.nr = a});\n" +
+      "\t\t{\n" +
+      "\t\t\tstruct my_struct a = {.nr = 1};\n" +
+      "\t\t}\n" +
+      "\t}\n" +
+      "\treturn 42;\n" +
+      "}\n"
+
+    assert_equal(1, @parser.count_number_of_pairs_of_braces_in_function(source))
+    assert_equal(6, @parser.count_number_of_pairs_of_braces_in_function(complex_source))
+  end
+
+  it "Count number of pairs of braces returns 0 if bad source is supplied" do
+    bad_source_0 =
+      "int foo(struct my_struct *s)\n" +
+      "{\n" +
+      "    return get_member_a(s) + 42;\n" +
+      "\n"                      # Missing closing brace
+    bad_source_1 =
+      "int bar(struct my_struct *s)\n" +
+      "{\n" +
+      "\tint a = 6;\n" +
+      "\tint res = foo(&(struct my_struct){.nr = a});\n" +
+      "\t{\n" +
+      "\t\tint a = 5;\n" +
+      "\t\tint res = foo(&(struct my_struct){.nr = a});\n" +
+      "\t\t{\n" +
+      "\t\t\n" +                # Missing closing brace
+      "\t}\n" +
+      "\treturn 42;\n" +
+      "}\n"
+
+    assert_equal(0, @parser.count_number_of_pairs_of_braces_in_function(bad_source_0))
+    assert_equal(0, @parser.count_number_of_pairs_of_braces_in_function(bad_source_1))
+  end
+
 end

--- a/test/unit/cmock_header_parser_test.rb
+++ b/test/unit/cmock_header_parser_test.rb
@@ -1842,18 +1842,59 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
       "};\n" +
       "int my_function(int a);\n" +
       "int my_better_function(struct my_struct *s);\n" +
-      "static inline int get_member_a(struct my_struct *s)\n" +
+      "static inline int staticinlinebar(struct my_struct *s)\n" + # This is a function with a lot of indentation levels, we should be able to handle it
+      "{\n" +
+      "\t{\n" +
+      "\t\t{\n" +
+      "\t\t\treturn s->a;\n" +
+      "\t\t}\n" +
+      "\t}\n" +
+      "}\n" +
+      "static inline int staticinlinefunc(struct my_struct *s)\n" +
       "{\n" +
       "    return s->a;\n" +
       "}\n" +
-      "inline static int my_func_0(int a)\n" +
-      "{\n" +
+      "int bar(struct my_struct *s);\n" + # A normal function to screw with our parser
+      "inline static int inlinestaticfunc(int a) {\n" +
       "    return a + 42;\n" +
       "}\n" +
-      "inline int my_func_1(struct my_struct *s)\n" +
+      "inline int StaticInlineFunc(struct my_struct *s)\n" +
       "{\n" +
       "    return get_member_a(s) + 42;\n" +
       "}\n" +
+      "int inline StaticInlineBar(struct my_struct *s)\n" +
+      "{\n" +
+      "    return get_member_a(s) + 42;\n" +
+      "}\n" +
+      "struct staticinlinestruct {\n" + # Add a structure declaration between the inline functions, just to make sure we don't touch it!
+      "int a;\n" +
+      "};\n" +
+      "\n" +
+      "struct staticinlinestruct fubarstruct(struct my_struct *s);\n" + # Another normal function to screw with our parser
+      "static inline struct staticinlinestruct inlinefubarfunction(struct my_struct *s)\n" +
+      "{\n" +
+      "    return (struct staticinlinestruct)*s;\n" +
+      "}\n" +
+      "int fubar(struct my_struct *s);\n" + # Another normal function to screw with our parser
+      "inline int stuff(int num)" +
+      "{" +
+      "    int reg = 0x12;" +
+      "    if (num > 0)" +
+      "    {" +
+      "      reg |= (0x0Eu);" +
+      "    }" +
+      "    else" +
+      "    {" +
+      "      reg |= (0x07u);" +
+      "    }" +
+      "    return reg;" +
+      "}" +
+      "\n" +
+      "int inline static dummy_func_2(int a, char b, float c) {" + # This is a sneaky one, inline static is placed AFTER the return value
+      "	c += 3.14;" +
+      "	b -= 32;" +
+      "	return a + (int)(b) + (int)c;" +
+      "}" +
       "#endif _NOINCLUDES\n"
 
     expected =
@@ -1883,9 +1924,21 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
       "};\n" +
       "int my_function(int a);\n" +
       "int my_better_function(struct my_struct *s);\n" +
-      "int get_member_a(struct my_struct *s);\n" +
-      "int my_func_0(int a);\n" +
-      "int my_func_1(struct my_struct *s);\n" +
+      "int staticinlinebar(struct my_struct *s);\n" +
+      "int staticinlinefunc(struct my_struct *s);\n" +
+      "int bar(struct my_struct *s);\n" +
+      "int inlinestaticfunc(int a);\n" +
+      "int StaticInlineFunc(struct my_struct *s);\n" +
+      "int StaticInlineBar(struct my_struct *s);\n" +
+      "struct staticinlinestruct {\n" +
+      "int a;\n" +
+      "};\n" +
+      "\n" +
+      "struct staticinlinestruct fubarstruct(struct my_struct *s);\n" +
+      "struct staticinlinestruct inlinefubarfunction(struct my_struct *s);\n" +
+      "int fubar(struct my_struct *s);\n" +
+      "int stuff(int num);\n" +
+      "int dummy_func_2(int a, char b, float c);" +
       "#endif _NOINCLUDES\n"
 
     assert_equal(expected, @parser.transform_inline_functions(source))


### PR DESCRIPTION
Hi,

I found some inline function scenario's could break the current way of working:
- when the name of a return type or function actually contains the word "inline" or "static", it was removed. This is probably an edge case but nevertheless could happen.
- I did some tests with Kinetis SDK and they have "interesting" header structures where they put structure definitions between the functions in the header. The old implementation of inline function mocking was not expecting this, so due to the aggressive regex sub(), it removed the structure declaration when transforming the inline functions causing compiler errors.

To be fully capable of handling these kinds of things + some weird functions with a lot of indentation levels/square-brackets, I don't see any other way than to actually parse the function body and count the number of levels to be removed. This guarantees we only remove inline function bodies and not structure body definitions (or something else) by accident.

My apologies for a new pull request basically fixing the same thing as #261 but don't know how I missed testing it with an actual SDK until today :)...

KR,

Laurens
