### PR TITLE
User provided patterns for inline function mocking

### DIFF
--- a/docs/CMock_Summary.md
+++ b/docs/CMock_Summary.md
@@ -530,8 +530,6 @@ from the defaults. We've tried to specify what the defaults are below.
   - "inline static"
   - "inline"
   - "static"
-  Note that the order is important here!
-  We go from specific to general to avoid wrongfully parsing the header.
   You can override these patterns, check out :inline_function_patterns.
 
   Enabling this feature does require a change in the build system that
@@ -679,6 +677,10 @@ from the defaults. We've tried to specify what the defaults are below.
   The default patterns are are:
 
   * default: ['(static\s+inline|inline\s+static)\s*', '(\bstatic\b|\binline\b)\s*']
+  * **note:**
+    The order of patterns is important here!
+    We go from specific patterns ('static inline') to general patterns ('inline'),
+    otherwise we would miss functions that use 'static inline' iso 'inline'.
 
 
 Compiled Options:

--- a/docs/CMock_Summary.md
+++ b/docs/CMock_Summary.md
@@ -525,6 +525,14 @@ from the defaults. We've tried to specify what the defaults are below.
   * `:include` will mock inlined functions
   * `:exclude` will ignore inlined functions (default).
 
+  CMock will look for the following default patterns (simplified from the actual regex):
+  - "static inline"
+  - "inline static"
+  - "inline"
+  - "static"
+  Note that the order is important here!
+  We go from specific to general to avoid wrongfully parsing the header.
+  You can override these patterns, check out :inline_function_patterns.
 
 * `:unity_helper_path`:
   If you have created a header with your own extensions to unity to
@@ -635,6 +643,17 @@ from the defaults. We've tried to specify what the defaults are below.
   * **note:**
     If this option is disabled, the mocked functions will return
     a default value (0) when called (and only if they have to return something of course).
+
+* `:inline_function_patterns`:
+  An array containing a list of strings to detect inline functions.
+  This option is only taken into account if you enable :treat_inlines.
+  These strings are interpreted as regex patterns so be sure to escape
+  certain characters. For example, use `:inline_function_patterns: ['static inline __attribute__ \(\(always_inline\)\)']`
+  to recognize `static inline __attribute__ ((always_inline)) int my_func(void)`
+  as an inline function.
+  The default patterns are are:
+
+  * default: ['(static\s+inline|inline\s+static)\s*', '(\bstatic\b|\binline\b)\s*']
 
 
 Compiled Options:

--- a/docs/CMock_Summary.md
+++ b/docs/CMock_Summary.md
@@ -534,6 +534,31 @@ from the defaults. We've tried to specify what the defaults are below.
   We go from specific to general to avoid wrongfully parsing the header.
   You can override these patterns, check out :inline_function_patterns.
 
+  Enabling this feature does require a change in the build system that
+  is using CMock.  To understand why, we need to give some more info
+  on how we are handling inline functions internally.
+  Let's say we want to mock a header called example.h.  example.h
+  contains inline functions, we cannot include this header in the
+  mocks or test code if we want to mock the inline functions simply
+  because the inline functions contain an implementation that we want
+  to override in our mocks!
+  So, to circumvent this, we generate a new header, also named
+  example.h, in the same directory as mock_example.h/c .  This newly
+  generated header should/is exactly the same as the original header,
+  only difference is the inline functions are transformed to 'normal'
+  functions declarations.  Placing the new header in the same
+  directory as mock_example.h/c ensures that they will include the new
+  header and not the old one.
+  However, CMock has no control in how the build system is configured
+  and which include paths the test code is compiled with.  In order
+  for the test code to also see the newly generated header ,and not
+  the old header with inline functions, the build system has to add
+  the mock folder to the include paths.
+  Furthermore, we need to keep the order of include paths in mind. We
+  have to set the mock folder before the other includes to avoid the
+  test code including the original header instead of the newly
+  generated header (without inline functions).
+
 * `:unity_helper_path`:
   If you have created a header with your own extensions to unity to
   handle your own types, you can set this argument to that path. CMock

--- a/lib/cmock_config.rb
+++ b/lib/cmock_config.rb
@@ -40,6 +40,7 @@ class CMockConfig
     :orig_header_include_fmt     => "#include \"%s\"",
     :array_size_type             => [],
     :array_size_name             => 'size|len',
+    :inline_function_patterns    => [],
   }
 
   def initialize(options=nil)

--- a/lib/cmock_config.rb
+++ b/lib/cmock_config.rb
@@ -40,7 +40,15 @@ class CMockConfig
     :orig_header_include_fmt     => "#include \"%s\"",
     :array_size_type             => [],
     :array_size_name             => 'size|len',
-    :inline_function_patterns    => [],
+
+    # Format to look for inline functions.
+    # This is a combination of "static" and "inline" keywords ("static inline", "inline static", "inline", "static")
+    # There are several possibilities:
+    # - sometimes they appear together, sometimes individually,
+    # - The keywords can appear before or after the return type (this is a compiler warning but people do weird stuff),
+    #   so we check for word boundaries when searching for them
+    # - We first remove "static inline" combinations and boil down to single inline or static statements
+    :inline_function_patterns    => ['(static\s+inline|inline\s+static)\s*', '(\bstatic\b|\binline\b)\s*'], # Last part (\s*) is just to remove whitespaces (only to prettify the output)
   }
 
   def initialize(options=nil)

--- a/lib/cmock_header_parser.rb
+++ b/lib/cmock_header_parser.rb
@@ -103,28 +103,15 @@ class CMockHeaderParser
   # Transform inline functions to regular functions in the source by the user
   # +source+:: String containing the source to be processed
   def transform_inline_functions(source)
-    # Format to look for inline functions.
-    # This is a combination of "static" and "inline" keywords ("static inline", "inline static", "inline", "static")
-    # There are several possibilities:
-    # - sometimes they appear together, sometimes individually,
-    # - The keywords can appear before or after the return type (this is a compiler warning but people do weird stuff),
-    #   so we check for word boundaries when searching for them
-    # - We first remove "static inline" combinations and boil down to single inline or static statements
-    inline_function_regex_formats = [
-      /(static\s+inline|inline\s+static)\s*/,        # Last part (\s*) is just to remove whitespaces (only to prettify the output)
-      /(\bstatic\b|\binline\b)\s*/,                  # Last part (\s*) is just to remove whitespaces (only to prettify the output)
-    ]
-    user_regex_formats = []
+    inline_function_regex_formats = []
     square_bracket_pair_regex_format = /\{[^\{\}]*\}/ # Regex to match one whole block enclosed by two square brackets
 
-    @inline_function_patterns.each { |user_format_string|
-      user_regex = Regexp.new(Regexp.quote(user_format_string))
+    # Convert user provided string patterns to regex
+    @inline_function_patterns.each do |user_format_string|
+      user_regex = Regexp.new(user_format_string)
       cleanup_spaces_after_user_regex = /\s*/
-      user_regex_formats << Regexp.new((user_regex.source) + cleanup_spaces_after_user_regex.source) # Convert user provided string to regex pattern
-    }
-
-    # We first parse the user regex to avoid removing basic inline keywords that the user regex depends upon
-    inline_function_regex_formats = user_regex_formats + inline_function_regex_formats
+      inline_function_regex_formats << Regexp.new(user_regex.source + cleanup_spaces_after_user_regex.source)
+    end
 
     # let's clean up the encoding in case they've done anything weird with the characters we might find
     source = source.force_encoding("ISO-8859-1").encode("utf-8", :replace => nil)

--- a/lib/cmock_header_parser.rb
+++ b/lib/cmock_header_parser.rb
@@ -114,7 +114,17 @@ class CMockHeaderParser
       /(static\s+inline|inline\s+static)\s*/,        # Last part (\s*) is just to remove whitespaces (only to prettify the output)
       /(\bstatic\b|\binline\b)\s*/,                  # Last part (\s*) is just to remove whitespaces (only to prettify the output)
     ]
+    user_regex_formats = []
     square_bracket_pair_regex_format = /\{[^\{\}]*\}/ # Regex to match one whole block enclosed by two square brackets
+
+    @inline_function_patterns.each { |user_format_string|
+      user_regex = Regexp.new(Regexp.quote(user_format_string))
+      cleanup_spaces_after_user_regex = /\s*/
+      user_regex_formats << Regexp.new((user_regex.source) + cleanup_spaces_after_user_regex.source) # Convert user provided string to regex pattern
+    }
+
+    # We first parse the user regex to avoid removing basic inline keywords that the user regex depends upon
+    inline_function_regex_formats = user_regex_formats + inline_function_regex_formats
 
     # let's clean up the encoding in case they've done anything weird with the characters we might find
     source = source.force_encoding("ISO-8859-1").encode("utf-8", :replace => nil)

--- a/lib/cmock_header_parser.rb
+++ b/lib/cmock_header_parser.rb
@@ -162,6 +162,14 @@ class CMockHeaderParser
       @local_as_void += void_types.flatten.uniq.compact
     end
 
+    # If user wants to mock inline functions,
+    # remove the (user specific) inline keywords before removing anything else to avoid missing an inline function
+    if (@treat_inlines == :include)
+      @inline_function_patterns.each { |user_format_string|
+        source.gsub!(/#{user_format_string}/, '') # remove user defined inline function patterns
+      }
+    end
+
     # smush multiline macros into single line (checking for continuation character at end of line '\')
     source.gsub!(/\s*\\\s*/m, ' ')
 

--- a/lib/cmock_header_parser.rb
+++ b/lib/cmock_header_parser.rb
@@ -236,13 +236,8 @@ class CMockHeaderParser
       src_lines.delete_if {|line| !(line =~ /(?:^|\s+)(?:extern)\s+/).nil?} # remove extern functions
     end
 
-    if (@treat_inlines == :include)
-      src_lines.each {
-        |src_line|
-        src_line.gsub!(/^inline/, "") # Remove "inline" so that they are 'normal' functions
-      }
-    else
-      src_lines.delete_if {|line| !(line =~ /(?:^|\s+)(?:inline)\s+/).nil?}        # remove inline functions
+    unless (@treat_inlines == :include)
+      src_lines.delete_if {|line| !(line =~ /(?:^|\s+)(?:inline)\s+/).nil?} # remove inline functions
     end
 
     src_lines.delete_if {|line| line.empty? } #drop empty lines

--- a/lib/cmock_header_parser.rb
+++ b/lib/cmock_header_parser.rb
@@ -6,7 +6,7 @@
 
 class CMockHeaderParser
 
-  attr_accessor :funcs, :c_attr_noconst, :c_attributes, :treat_as_void, :treat_externs, :treat_inlines
+  attr_accessor :funcs, :c_attr_noconst, :c_attributes, :treat_as_void, :treat_externs, :treat_inlines, :inline_function_patterns
 
   def initialize(cfg)
     @funcs = []
@@ -25,6 +25,7 @@ class CMockHeaderParser
     @verbosity = cfg.verbosity
     @treat_externs = cfg.treat_externs
     @treat_inlines = cfg.treat_inlines
+    @inline_function_patterns = cfg.inline_function_patterns
     @c_strippables += ['extern'] if (@treat_externs == :include) #we'll need to remove the attribute if we're allowing externs
     @c_strippables += ['inline'] if (@treat_inlines == :include) #we'll need to remove the attribute if we're allowing inlines
   end

--- a/test/unit/cmock_config_test.rb
+++ b/test/unit/cmock_config_test.rb
@@ -20,6 +20,7 @@ describe CMockConfig, "Verify CMockConfig Module" do
     assert_equal(CMockConfig::CMockDefaultOptions[:plugins],               config.plugins)
     assert_equal(CMockConfig::CMockDefaultOptions[:treat_externs],         config.treat_externs)
     assert_equal(CMockConfig::CMockDefaultOptions[:treat_inlines],         config.treat_inlines)
+    assert_equal(CMockConfig::CMockDefaultOptions[:inline_function_patterns],   config.inline_function_patterns)
   end
 
   it "replace only options specified in a hash" do
@@ -32,6 +33,7 @@ describe CMockConfig, "Verify CMockConfig Module" do
     assert_equal(CMockConfig::CMockDefaultOptions[:plugins],                config.plugins)
     assert_equal(CMockConfig::CMockDefaultOptions[:treat_externs],          config.treat_externs)
     assert_equal(CMockConfig::CMockDefaultOptions[:treat_inlines],          config.treat_inlines)
+    assert_equal(CMockConfig::CMockDefaultOptions[:inline_function_patterns],   config.inline_function_patterns)
   end
 
   it "replace only options specified in a yaml file" do
@@ -43,6 +45,7 @@ describe CMockConfig, "Verify CMockConfig Module" do
     assert_equal(test_plugins,                                              config.plugins)
     assert_equal(:include,                                                  config.treat_externs)
     assert_equal(:include,                                                  config.treat_inlines)
+    assert_equal(['MY_INLINE_FUNCTION_DECLARATION_PATTERN'],                config.inline_function_patterns)
   end
 
   it "populate treat_as map with internal standard_treat_as_map defaults, redefine defaults, and add custom values" do

--- a/test/unit/cmock_config_test.yml
+++ b/test/unit/cmock_config_test.yml
@@ -4,3 +4,4 @@
     - 'pizza'
   :treat_externs:  :include
   :treat_inlines:  :include
+  :inline_function_patterns: ['MY_INLINE_FUNCTION_DECLARATION_PATTERN']

--- a/test/unit/cmock_generator_main_test.rb
+++ b/test/unit/cmock_generator_main_test.rb
@@ -55,7 +55,6 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
     @config.expect :subdir, nil
     @config.expect :fail_on_unexpected_calls, true
     @config.expect :treat_inlines, :exclude
-    @config.expect :inline_function_patterns, []
     @cmock_generator = CMockGenerator.new(@config, @file_writer, @utils, @plugins)
     @cmock_generator.module_name = @module_name
     @cmock_generator.mock_name = "Mock#{@module_name}"
@@ -75,7 +74,6 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
     @config.expect :subdir, nil
     @config.expect :fail_on_unexpected_calls, true
     @config.expect :treat_inlines, :exclude
-    @config.expect :inline_function_patterns, []
     @cmock_generator_strict = CMockGenerator.new(@config, @file_writer, @utils, @plugins)
     @cmock_generator_strict.module_name = @module_name
     @cmock_generator_strict.mock_name = "Mock#{@module_name}"
@@ -138,7 +136,6 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
     @config.expect :subdir, nil
     @config.expect :fail_on_unexpected_calls, true
     @config.expect :treat_inlines, :exclude
-    @config.expect :inline_function_patterns, []
     @cmock_generator2 = CMockGenerator.new(@config, @file_writer, @utils, @plugins)
     @cmock_generator2.module_name = "Pout-Pout Fish"
     @cmock_generator2.mock_name = "MockPout-Pout Fish"

--- a/test/unit/cmock_generator_main_test.rb
+++ b/test/unit/cmock_generator_main_test.rb
@@ -55,6 +55,7 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
     @config.expect :subdir, nil
     @config.expect :fail_on_unexpected_calls, true
     @config.expect :treat_inlines, :exclude
+    @config.expect :inline_function_patterns, []
     @cmock_generator = CMockGenerator.new(@config, @file_writer, @utils, @plugins)
     @cmock_generator.module_name = @module_name
     @cmock_generator.mock_name = "Mock#{@module_name}"
@@ -74,6 +75,7 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
     @config.expect :subdir, nil
     @config.expect :fail_on_unexpected_calls, true
     @config.expect :treat_inlines, :exclude
+    @config.expect :inline_function_patterns, []
     @cmock_generator_strict = CMockGenerator.new(@config, @file_writer, @utils, @plugins)
     @cmock_generator_strict.module_name = @module_name
     @cmock_generator_strict.mock_name = "Mock#{@module_name}"
@@ -136,6 +138,7 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
     @config.expect :subdir, nil
     @config.expect :fail_on_unexpected_calls, true
     @config.expect :treat_inlines, :exclude
+    @config.expect :inline_function_patterns, []
     @cmock_generator2 = CMockGenerator.new(@config, @file_writer, @utils, @plugins)
     @cmock_generator2.module_name = "Pout-Pout Fish"
     @cmock_generator2.mock_name = "MockPout-Pout Fish"

--- a/test/unit/cmock_header_parser_test.rb
+++ b/test/unit/cmock_header_parser_test.rb
@@ -24,7 +24,7 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
     @config.expect :verbosity, 1
     @config.expect :treat_externs, :exclude
     @config.expect :treat_inlines, :exclude
-    @config.expect :inline_function_patterns, ['static __inline__ __attribute__ \(\(always_inline\)\)', 'static __inline__', '(static\s+inline|inline\s+static)\s*', '(\bstatic\b|\binline\b)\s*']
+    @config.expect :inline_function_patterns, ['(static\s+inline|inline\s+static)\s*', '(\bstatic\b|\binline\b)\s*']
     @config.expect :array_size_type, ['int', 'size_t']
     @config.expect :array_size_name, 'size|len'
 
@@ -2020,6 +2020,8 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
       "uint16_t attributealwaysinlinefuncname(void);\n" +
       "\n"
 
+    @parser.treat_inlines = :include
+    @parser.inline_function_patterns = ['static __inline__ __attribute__ \(\(always_inline\)\)', 'static __inline__', 'static inline']
     assert_equal(expected, @parser.transform_inline_functions(source))
   end
 

--- a/test/unit/cmock_header_parser_test.rb
+++ b/test/unit/cmock_header_parser_test.rb
@@ -24,6 +24,7 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
     @config.expect :verbosity, 1
     @config.expect :treat_externs, :exclude
     @config.expect :treat_inlines, :exclude
+    @config.expect :inline_function_patterns, ['static __inline__ __attribute__ ((always_inline))', 'static __inline__']
     @config.expect :array_size_type, ['int', 'size_t']
     @config.expect :array_size_name, 'size|len'
 

--- a/test/unit/cmock_header_parser_test.rb
+++ b/test/unit/cmock_header_parser_test.rb
@@ -510,6 +510,37 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
     assert_equal(expected, @parser.import_source(source).map!{|s|s.strip})
   end
 
+  it "Include inline functions that contain user defined inline function formats" do
+    source =
+      "uint32 foo(unsigned int);\n" +
+      "uint32 bar(unsigned int);\n" +
+      "inline void inlineBar(void)\n" +
+      "{\n" +
+      "    return 43;\n" +
+      "}\n" +
+      "static __inline__ __attribute__ ((always_inline)) int alwaysinlinefunc(int a)\n" +
+      "{\n" +
+      "    return a + inlineBar();\n" +
+      "}\n" +
+      "static __inline__ void inlinebar(unsigned int)\n" +
+      "{\n" +
+      " int a = alwaysinlinefunc()\n" +
+      "}\n"
+
+    expected =
+      [
+      "uint32 foo(unsigned int)",
+      "uint32 bar(unsigned int)",
+      "void inlineBar(void)",
+      "int alwaysinlinefunc(int a)",
+      "void inlinebar(unsigned int)"
+      ]
+
+    @parser.treat_inlines = :include
+    @parser.inline_function_patterns = ['static __inline__ __attribute__ \(\(always_inline\)\)', 'static __inline__', '\binline\b']
+    assert_equal(expected, @parser.import_source(source).map!{|s|s.strip})
+  end
+
   it "remove defines" do
     source =
       "#define whatever you feel like defining\n" +

--- a/test/unit/cmock_header_parser_test.rb
+++ b/test/unit/cmock_header_parser_test.rb
@@ -2029,31 +2029,4 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
     assert_equal(0, @parser.count_number_of_pairs_of_braces_in_function(bad_source_2))
   end
 
-  it "Transform inline functions takes user provided patterns into account" do
-    source =
-      "static inline int staticinlinefunc(struct my_struct *s)\n" + # 'normal' inline pattern
-      "{\n" +
-      "    return s->a;\n" +
-      "}\n" +
-      "static __inline__ int dummy_func_2(int a, char b, float c) {\n" + # First user pattern
-      "	c += 3.14;\n" +
-      "	b -= 32;\n" +
-      "	return a + (int)(b) + (int)c;\n" +
-      "}\n" +
-      "static __inline__ __attribute__ ((always_inline)) uint16_t attributealwaysinlinefuncname(void) {\n" + # Second user pattern
-      "	return (uint16_t)(42);\n" +
-      "}\n" +
-      "\n"
-
-    expected =
-      "int staticinlinefunc(struct my_struct *s);\n" +
-      "int dummy_func_2(int a, char b, float c);\n" +
-      "uint16_t attributealwaysinlinefuncname(void);\n" +
-      "\n"
-
-    @parser.treat_inlines = :include
-    @parser.inline_function_patterns = ['static __inline__ __attribute__ \(\(always_inline\)\)', 'static __inline__', 'static inline']
-    assert_equal(expected, @parser.transform_inline_functions(source))
-  end
-
 end

--- a/test/unit/cmock_header_parser_test.rb
+++ b/test/unit/cmock_header_parser_test.rb
@@ -1998,4 +1998,29 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
     assert_equal(0, @parser.count_number_of_pairs_of_braces_in_function(bad_source_2))
   end
 
+  it "Transform inline functions takes user provided patterns into account" do
+    source =
+      "static inline int staticinlinefunc(struct my_struct *s)\n" + # 'normal' inline pattern
+      "{\n" +
+      "    return s->a;\n" +
+      "}\n" +
+      "static __inline__ int dummy_func_2(int a, char b, float c) {\n" + # First user pattern
+      "	c += 3.14;\n" +
+      "	b -= 32;\n" +
+      "	return a + (int)(b) + (int)c;\n" +
+      "}\n" +
+      "static __inline__ __attribute__ ((always_inline)) uint16_t attributealwaysinlinefuncname(void) {\n" + # Second user pattern
+      "	return (uint16_t)(42);\n" +
+      "}\n" +
+      "\n"
+
+    expected =
+      "int staticinlinefunc(struct my_struct *s);\n" +
+      "int dummy_func_2(int a, char b, float c);\n" +
+      "uint16_t attributealwaysinlinefuncname(void);\n" +
+      "\n"
+
+    assert_equal(expected, @parser.transform_inline_functions(source))
+  end
+
 end

--- a/test/unit/cmock_header_parser_test.rb
+++ b/test/unit/cmock_header_parser_test.rb
@@ -24,7 +24,7 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
     @config.expect :verbosity, 1
     @config.expect :treat_externs, :exclude
     @config.expect :treat_inlines, :exclude
-    @config.expect :inline_function_patterns, ['static __inline__ __attribute__ ((always_inline))', 'static __inline__']
+    @config.expect :inline_function_patterns, ['static __inline__ __attribute__ \(\(always_inline\)\)', 'static __inline__', '(static\s+inline|inline\s+static)\s*', '(\bstatic\b|\binline\b)\s*']
     @config.expect :array_size_type, ['int', 'size_t']
     @config.expect :array_size_name, 'size|len'
 


### PR DESCRIPTION
Proposal for #264 
Yet another pull request for the inline function mocking (I will stop at one point, I promise :)...)
A new configuration option `:inline_function_patterns` is added to make the inline function  recognition fully user-configurable. We provide defaults which are the old ones I had previously hardcoded in the header_parser.

The user does have to keep in mind the patterns he provides are directly fed to a Regexp and thus must be properly escaped etc.
I tried adding `Regexp.escape` to remove problem characters, but this conflicts with actual regex string patterns we don't want escaped (f.e. `\b` disappears) and anyway, I think providing actual regex patterns is in line with the way f.e. `:strippables` works so I guess users are used to this by now. (correct me if I'm wrong)

KR,

Laurens