### PR TITLE
Revert "Add quick pointer check before memory comparisons (#224)"

### DIFF
--- a/lib/cmock_generator_utils.rb
+++ b/lib/cmock_generator_utils.rb
@@ -181,7 +181,6 @@ class CMockGeneratorUtils
     lines << "  if (!#{ignore})\n" if @ignore_arg
     lines << "  {\n"
     lines << "    UNITY_SET_DETAILS(CMockString_#{function[:name]},CMockString_#{arg_name});\n"
-    lines << "    if (#{pre}#{expected} != #{pre}#{arg_name}) {\n"
     case(unity_func)
       when "UNITY_TEST_ASSERT_EQUAL_MEMORY"
         c_type_local = c_type.gsub(/\*$/,'')
@@ -207,7 +206,7 @@ class CMockGeneratorUtils
       else
         lines << "    #{unity_func}(#{pre}#{expected}, #{pre}#{arg_name}, cmock_line, CMockStringMismatch);\n"
     end
-    lines << "      }\n  }\n"
+    lines << "  }\n"
     lines
   end
 
@@ -218,7 +217,6 @@ class CMockGeneratorUtils
     lines << "  if (!#{ignore})\n" if @ignore_arg
     lines << "  {\n"
     lines << "    UNITY_SET_DETAILS(CMockString_#{function[:name]},CMockString_#{arg_name});\n"
-    lines << "    if (#{pre}#{expected} != #{pre}#{arg_name}) {\n"
     case(unity_func)
       when "UNITY_TEST_ASSERT_EQUAL_MEMORY"
         c_type_local = c_type.gsub(/\*$/,'')
@@ -246,7 +244,7 @@ class CMockGeneratorUtils
       else
         lines << "    #{unity_func}(#{pre}#{expected}, #{pre}#{arg_name}, cmock_line, CMockStringMismatch);\n"
     end
-    lines << "    }\n  }\n"
+    lines << "  }\n"
     lines
   end
 

--- a/test/unit/cmock_generator_utils_test.rb
+++ b/test/unit/cmock_generator_utils_test.rb
@@ -301,9 +301,7 @@ describe CMockGeneratorUtils, "Verify CMockGeneratorUtils Module" do
     expected = "  if (!cmock_call_instance->IgnoreArg_MyInt)\n" +
                "  {\n" +
                "    UNITY_SET_DETAILS(CMockString_Pear,CMockString_MyInt);\n" +
-               "    if (cmock_call_instance->Expected_MyInt != MyInt) {\n" +
                "    UNITY_TEST_ASSERT_EQUAL_INT(cmock_call_instance->Expected_MyInt, MyInt, cmock_line, CMockStringMismatch);\n" +
-               "    }\n" +
                "  }\n"
     @unity_helper.expect :nil?, false
     @unity_helper.expect :get_helper, ['UNITY_TEST_ASSERT_EQUAL_INT',''], ['int']
@@ -316,14 +314,12 @@ describe CMockGeneratorUtils, "Verify CMockGeneratorUtils Module" do
     expected = "  if (!cmock_call_instance->IgnoreArg_MyIntPtr)\n" +
                "  {\n" +
                "    UNITY_SET_DETAILS(CMockString_Pear,CMockString_MyIntPtr);\n" +
-               "    if (cmock_call_instance->Expected_MyIntPtr != MyIntPtr) {\n" +
                "    if (cmock_call_instance->Expected_MyIntPtr == NULL)\n" +
                "      { UNITY_TEST_ASSERT_NULL(MyIntPtr, cmock_line, CMockStringExpNULL); }\n" +
                "    else if (cmock_call_instance->Expected_MyIntPtr_Depth == 0)\n" +
                "      { UNITY_TEST_ASSERT_EQUAL_PTR(cmock_call_instance->Expected_MyIntPtr, MyIntPtr, cmock_line, CMockStringMismatch); }\n" +
                "    else\n" +
                "      { UNITY_TEST_ASSERT_EQUAL_INT_ARRAY(cmock_call_instance->Expected_MyIntPtr, MyIntPtr, cmock_call_instance->Expected_MyIntPtr_Depth, cmock_line, CMockStringMismatch); }\n" +
-               "    }\n" +
                "  }\n"
     @unity_helper.expect :nil?, false
     @unity_helper.expect :get_helper, ['UNITY_TEST_ASSERT_EQUAL_INT_ARRAY',''], ['int*']
@@ -336,9 +332,7 @@ describe CMockGeneratorUtils, "Verify CMockGeneratorUtils Module" do
     expected = "  if (!cmock_call_instance->IgnoreArg_MyStr)\n" +
                "  {\n" +
                "    UNITY_SET_DETAILS(CMockString_Pear,CMockString_MyStr);\n" +
-               "    if (cmock_call_instance->Expected_MyStr != MyStr) {\n" +
                "    UNITY_TEST_ASSERT_EQUAL_STRING(cmock_call_instance->Expected_MyStr, MyStr, cmock_line, CMockStringMismatch);\n" +
-               "    }\n" +
                "  }\n"
     @unity_helper.expect :nil?, false
     @unity_helper.expect :get_helper, ['UNITY_TEST_ASSERT_EQUAL_STRING',''], ['const char*']
@@ -351,12 +345,10 @@ describe CMockGeneratorUtils, "Verify CMockGeneratorUtils Module" do
     expected = "  if (!cmock_call_instance->IgnoreArg_MyMyType)\n" +
                "  {\n" +
                "    UNITY_SET_DETAILS(CMockString_Pear,CMockString_MyMyType);\n" +
-               "    if (cmock_call_instance->Expected_MyMyType != MyMyType) {\n" +
                "    if (cmock_call_instance->Expected_MyMyType == NULL)\n" +
                "      { UNITY_TEST_ASSERT_NULL(MyMyType, cmock_line, CMockStringExpNULL); }\n" +
                "    else\n" +
                "      { UNITY_TEST_ASSERT_EQUAL_MEMORY_ARRAY((void*)(cmock_call_instance->Expected_MyMyType), (void*)(MyMyType), sizeof(MY_TYPE), 1, cmock_line, CMockStringMismatch); }\n" +
-               "    }\n" +
                "  }\n"
     @unity_helper.expect :nil?, false
     @unity_helper.expect :get_helper, ['UNITY_TEST_ASSERT_EQUAL_MEMORY_ARRAY', ''],  ['MY_TYPE']
@@ -369,9 +361,7 @@ describe CMockGeneratorUtils, "Verify CMockGeneratorUtils Module" do
     expected = "  if (!cmock_call_instance->IgnoreArg_MyMyType)\n" +
                "  {\n" +
                "    UNITY_SET_DETAILS(CMockString_Pear,CMockString_MyMyType);\n" +
-               "    if (cmock_call_instance->Expected_MyMyType != MyMyType) {\n" +
                "    UNITY_TEST_ASSERT_EQUAL_MY_TYPE(cmock_call_instance->Expected_MyMyType, MyMyType, cmock_line, CMockStringMismatch);\n" +
-               "    }\n" +
                "  }\n"
     @unity_helper.expect :nil?, false
     @unity_helper.expect :get_helper, ['UNITY_TEST_ASSERT_EQUAL_MY_TYPE',  ''], ['MY_TYPE']
@@ -384,14 +374,12 @@ describe CMockGeneratorUtils, "Verify CMockGeneratorUtils Module" do
     expected = "  if (!cmock_call_instance->IgnoreArg_MyMyTypePtr)\n" +
                "  {\n" +
                "    UNITY_SET_DETAILS(CMockString_Pear,CMockString_MyMyTypePtr);\n" +
-               "    if (cmock_call_instance->Expected_MyMyTypePtr != MyMyTypePtr) {\n" +
                "    if (cmock_call_instance->Expected_MyMyTypePtr == NULL)\n" +
                "      { UNITY_TEST_ASSERT_NULL(MyMyTypePtr, cmock_line, CMockStringExpNULL); }\n" +
                "    else if (cmock_call_instance->Expected_MyMyTypePtr_Depth == 0)\n" +
                "      { UNITY_TEST_ASSERT_EQUAL_PTR(cmock_call_instance->Expected_MyMyTypePtr, MyMyTypePtr, cmock_line, CMockStringMismatch); }\n" +
                "    else\n" +
                "      { UNITY_TEST_ASSERT_EQUAL_MY_TYPE_ARRAY(cmock_call_instance->Expected_MyMyTypePtr, MyMyTypePtr, cmock_call_instance->Expected_MyMyTypePtr_Depth, cmock_line, CMockStringMismatch); }\n" +
-               "    }\n" +
                "  }\n"
     @unity_helper.expect :nil?, false
     @unity_helper.expect :get_helper, ['UNITY_TEST_ASSERT_EQUAL_MY_TYPE_ARRAY', ''], ['MY_TYPE*']
@@ -404,9 +392,7 @@ describe CMockGeneratorUtils, "Verify CMockGeneratorUtils Module" do
     expected = "  if (!cmock_call_instance->IgnoreArg_MyMyType)\n" +
                "  {\n" +
                "    UNITY_SET_DETAILS(CMockString_Pear,CMockString_MyMyType);\n" +
-               "    if (&cmock_call_instance->Expected_MyMyType != &MyMyType) {\n" +
                "    UNITY_TEST_ASSERT_EQUAL_MY_TYPE_ARRAY(&cmock_call_instance->Expected_MyMyType, &MyMyType, 1, cmock_line, CMockStringMismatch);\n" +
-               "    }\n" +
                "  }\n"
     @unity_helper.expect :nil?, false
     @unity_helper.expect :get_helper, ['UNITY_TEST_ASSERT_EQUAL_MY_TYPE_ARRAY', '&'], ['MY_TYPE']


### PR DESCRIPTION
It didn't add direct comparisons only for pointer arguments, but
also other types of arguments like structs, which can't be compared
with '==' and cause a compiler error instead.

To reproduce, just enable the :array plugin in
system/test_interactions/expect_and_return_custom_types.yml:

In function ‘foo’:
error: invalid operands to binary != (have ‘EXAMPLE_STRUCT_T’ {aka
‘struct _EXAMPLE_STRUCT_T’} and ‘EXAMPLE_STRUCT_T’ {aka ‘struct
 _EXAMPLE_STRUCT_T’})
   59 |     if (cmock_call_instance->Expected_a != a) {
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^~

This reverts commit 4df532afccb7e7d1437f79764cc3b0619302c822.