### PR TITLE
Fix parsing of inline function declarations/macro's

### DIFF
--- a/lib/cmock_header_parser.rb
+++ b/lib/cmock_header_parser.rb
@@ -107,10 +107,12 @@ class CMockHeaderParser
     square_bracket_pair_regex_format = /\{[^\{\}]*\}/ # Regex to match one whole block enclosed by two square brackets
 
     # Convert user provided string patterns to regex
+    # Use word bounderies before and after the user regex to limit matching to actual word iso part of a word
     @inline_function_patterns.each do |user_format_string|
       user_regex = Regexp.new(user_format_string)
-      cleanup_spaces_after_user_regex = /\s*/
-      inline_function_regex_formats << Regexp.new(user_regex.source + cleanup_spaces_after_user_regex.source)
+      word_boundary_before_user_regex = /\b/
+      cleanup_spaces_after_user_regex = /[ ]*\b/
+      inline_function_regex_formats << Regexp.new(word_boundary_before_user_regex.source + user_regex.source + cleanup_spaces_after_user_regex.source)
     end
 
     puts "INLINE REGEXS"

--- a/lib/cmock_header_parser.rb
+++ b/lib/cmock_header_parser.rb
@@ -174,7 +174,7 @@ class CMockHeaderParser
         first_open_bracket = inline_function_match.post_match.index("{")
         first_semicolon    = inline_function_match.post_match.index(";")
 
-        if first_open_bracket.nil? or first_semicolon < first_open_bracket
+        if first_open_bracket.nil? or (!first_semicolon.nil? and first_semicolon < first_open_bracket)
           puts "DECLARATION, IGNORE"
           source = inline_function_match.pre_match + inline_function_match.post_match
           next

--- a/lib/cmock_header_parser.rb
+++ b/lib/cmock_header_parser.rb
@@ -16,7 +16,8 @@ class CMockHeaderParser
     @c_calling_conventions = cfg.c_calling_conventions.uniq
     @treat_as_array = cfg.treat_as_array
     @treat_as_void = (['void'] + cfg.treat_as_void).uniq
-    @declaration_parse_matcher = /([\w\s\*\(\),\[\]]+??)\(([\w\s\*\(\),\.\[\]+-]*)\)$/m
+    @function_declaration_parse_base_match = '([\w\s\*\(\),\[\]]+??)\(([\w\s\*\(\),\.\[\]+-]*)\)'
+    @declaration_parse_matcher = /#{@function_declaration_parse_base_match}$/m
     @standards = (['int','short','char','long','unsigned','signed'] + cfg.treat_as.keys).uniq
     @array_size_name = cfg.array_size_name
     @array_size_type = (['int', 'size_t'] + cfg.array_size_type).uniq
@@ -156,7 +157,7 @@ class CMockHeaderParser
         # 2. Determine if we are dealing with an inline function declaration iso function definition
         # If the start of the post-match string is a function-declaration-like string (something ending with semicolon after the function arguments),
         # we are dealing with a inline function declaration
-        if /\A.*\b\([^\)]*\)\s*;/ === inline_function_match.post_match
+        if /\A#{@function_declaration_parse_base_match}\s*;/m === inline_function_match.post_match
           # Only remove the inline part from the function declaration, leaving the function declaration won't do any harm
           source = inline_function_match.pre_match + inline_function_match.post_match
           next

--- a/lib/cmock_header_parser.rb
+++ b/lib/cmock_header_parser.rb
@@ -133,14 +133,16 @@ class CMockHeaderParser
 
     inline_function_regex_formats.each do |format|
       loop do
-        inline_function_match = source.match(/#{format}/) # Search for inline function declaration
-        break if nil == inline_function_match             # No inline functions so nothing to do
-
-
         puts "--------------------"
         puts "FORMAT USED"
         puts format
         puts
+
+        inline_function_match = source.match(/#{format}/) # Search for inline function declaration
+        if nil == inline_function_match             # No inline functions so nothing to do
+          puts "NO INLNE MATCH FOUND, GOING TO NEXT"
+          break
+        end
 
         puts "PRE MATCH"
         puts inline_function_match.pre_match
@@ -156,7 +158,10 @@ class CMockHeaderParser
 
         total_pairs_to_remove = count_number_of_pairs_of_braces_in_function(inline_function_match.post_match)
 
-        break if 0 == total_pairs_to_remove # Bad source?
+        if 0 == total_pairs_to_remove # Bad source?
+          puts "NO PAIRS/FUNCTION BODY FOUND TO REMOVE, GOING TO NEXT"
+          break
+        end
 
         inline_function_stripped = inline_function_match.post_match
 

--- a/lib/cmock_header_parser.rb
+++ b/lib/cmock_header_parser.rb
@@ -113,6 +113,10 @@ class CMockHeaderParser
       inline_function_regex_formats << Regexp.new(user_regex.source + cleanup_spaces_after_user_regex.source)
     end
 
+    puts "INLINE REGEXS"
+    puts inline_function_regex_formats
+    puts
+
     # let's clean up the encoding in case they've done anything weird with the characters we might find
     source = source.force_encoding("ISO-8859-1").encode("utf-8", :replace => nil)
 
@@ -132,6 +136,24 @@ class CMockHeaderParser
         inline_function_match = source.match(/#{format}/) # Search for inline function declaration
         break if nil == inline_function_match             # No inline functions so nothing to do
 
+
+        puts "--------------------"
+        puts "FORMAT USED"
+        puts format
+        puts
+
+        puts "PRE MATCH"
+        puts inline_function_match.pre_match
+        puts
+
+        puts "MATCH"
+        puts inline_function_match.to_s
+        puts
+
+        puts "POST MATCH"
+        puts inline_function_match.post_match
+        puts
+
         total_pairs_to_remove = count_number_of_pairs_of_braces_in_function(inline_function_match.post_match)
 
         break if 0 == total_pairs_to_remove # Bad source?
@@ -141,6 +163,12 @@ class CMockHeaderParser
         total_pairs_to_remove.times do
           inline_function_stripped.sub!(/\s*#{square_bracket_pair_regex_format}/, ";") # Remove inline implementation (+ some whitespace because it's prettier)
         end
+
+        puts "STRIPPED INLINE"
+        puts total_pairs_to_remove
+        puts inline_function_stripped
+        puts "--------------------"
+
 
         source = inline_function_match.pre_match + inline_function_stripped # Make new source with the inline function removed and move on to the next
       end

--- a/lib/cmock_header_parser.rb
+++ b/lib/cmock_header_parser.rb
@@ -172,12 +172,8 @@ class CMockHeaderParser
           next
         end
 
-        # Determine if we are dealing with a declaration or a function definition
-        first_open_bracket = inline_function_match.post_match.index("{")
-        first_semicolon    = inline_function_match.post_match.index(";")
-
-        if first_open_bracket.nil? or (!first_semicolon.nil? and first_semicolon < first_open_bracket)
-          puts "DECLARATION, IGNORE"
+        if /\A.*\b\([^\)]*\)\s*;/ === inline_function_match.post_match
+          # Only remove the inline part from the function declaration, leaving the function declaration won't do any harm
           source = inline_function_match.pre_match + inline_function_match.post_match
           next
         end

--- a/lib/cmock_header_parser.rb
+++ b/lib/cmock_header_parser.rb
@@ -160,7 +160,7 @@ class CMockHeaderParser
         first_open_bracket = inline_function_match.post_match.index("{")
         first_semicolon    = inline_function_match.post_match.index(";")
 
-        if first_semicolon < first_open_bracket
+        if first_open_bracket.nil? or first_semicolon < first_open_bracket
           puts "DECLARATION, IGNORE"
           source = inline_function_match.pre_match + inline_function_match.post_match
           next

--- a/lib/cmock_header_parser.rb
+++ b/lib/cmock_header_parser.rb
@@ -156,6 +156,16 @@ class CMockHeaderParser
         puts inline_function_match.post_match
         puts
 
+        # Determine if we are dealing with a declaration or a function definition
+        first_open_bracket = inline_function_match.post_match.index("{")
+        first_semicolon    = inline_function_match.post_match.index(";")
+
+        if first_semicolon < first_open_bracket
+          puts "DECLARATION, IGNORE"
+          source = inline_function_match.pre_match + inline_function_match.post_match
+          next
+        end
+
         total_pairs_to_remove = count_number_of_pairs_of_braces_in_function(inline_function_match.post_match)
 
         if 0 == total_pairs_to_remove # Bad source?

--- a/test/unit/cmock_header_parser_test.rb
+++ b/test/unit/cmock_header_parser_test.rb
@@ -2083,13 +2083,20 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
     assert_equal(expected, @parser.parse("module", source)[:functions])
   end
 
-  it "Transform inline functions does not touch inline function declarations" do
+  it "Transform inline functions can handle inline function declarations" do
     source =
-      "static inline int dummy_func_decl(int a, char b, float c);\n" + # First declaration user pattern
+      "static inline int dummy_func_decl(int a, char b, float c);\n" + # First declaration
+      "static inline int dummy_func_decl2(int a, char b, float c)\n\n\n\n\n\n;\n" + # Second declaration with a lot of newlines before the semicolon to mess with the parser
       "static inline int staticinlinefunc(struct my_struct *s)\n" + # 'normal' inline pattern
       "{\n" +
       "    return dummy_func_decl(1, 1, 1);\n" +
       "}\n" +
+      "struct my_struct_with_inline_in_it\n" # struct definition in between to mess with the parser
+      "{\n" +
+      "    int a;\n" +
+      "    char b;\n" +
+      "    float inlineb;\n" +
+      "};\n" +
       "static inline int dummy_func_decl(int a, char b, float c) {\n" + # Second user pattern
       "	return 42;\n" +
       "}\n" +
@@ -2097,7 +2104,14 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
 
     expected =
       "int dummy_func_decl(int a, char b, float c);\n" +
+      "int dummy_func_decl2(int a, char b, float c)\n\n\n\n\n\n;\n" + # Second declaration with a lot of newlines until the semicolon to mess with the parser
       "int staticinlinefunc(struct my_struct *s);\n" +
+      "struct my_struct_with_inline_in_it\n"
+      "{\n" +
+      "    int a;\n" +
+      "    char b;\n" +
+      "    float inlineb;\n" +
+      "};\n" +
       "int dummy_func_decl(int a, char b, float c);\n" +
       "\n"
 

--- a/test/unit/cmock_header_parser_test.rb
+++ b/test/unit/cmock_header_parser_test.rb
@@ -2083,30 +2083,25 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
     assert_equal(expected, @parser.parse("module", source)[:functions])
   end
 
-  it "Transform inline functions takes user provided patterns into account" do
+  it "Transform inline functions does not touch inline function declarations" do
     source =
+      "static inline int dummy_func_decl(int a, char b, float c);\n" + # First declaration user pattern
       "static inline int staticinlinefunc(struct my_struct *s)\n" + # 'normal' inline pattern
       "{\n" +
-      "    return s->a;\n" +
+      "    return dummy_func_decl(1, 1, 1);\n" +
       "}\n" +
-      "static __inline__ int dummy_func_2(int a, char b, float c) {\n" + # First user pattern
-      "	c += 3.14;\n" +
-      "	b -= 32;\n" +
-      "	return a + (int)(b) + (int)c;\n" +
-      "}\n" +
-      "static __inline__ __attribute__ ((always_inline)) uint16_t attributealwaysinlinefuncname(void) {\n" + # Second user pattern
-      "	return (uint16_t)(42);\n" +
+      "static inline int dummy_func_decl(int a, char b, float c) {\n" + # Second user pattern
+      "	return 42;\n" +
       "}\n" +
       "\n"
 
     expected =
+      "int dummy_func_decl(int a, char b, float c);\n" +
       "int staticinlinefunc(struct my_struct *s);\n" +
-      "int dummy_func_2(int a, char b, float c);\n" +
-      "uint16_t attributealwaysinlinefuncname(void);\n" +
+      "int dummy_func_decl(int a, char b, float c);\n" +
       "\n"
 
     @parser.treat_inlines = :include
-    @parser.inline_function_patterns = ['static __inline__ __attribute__ \(\(always_inline\)\)', 'static __inline__', 'static inline']
     assert_equal(expected, @parser.transform_inline_functions(source))
   end
 

--- a/test/unit/cmock_header_parser_test.rb
+++ b/test/unit/cmock_header_parser_test.rb
@@ -2083,4 +2083,53 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
     assert_equal(expected, @parser.parse("module", source)[:functions])
   end
 
+  it "Transform inline functions takes user provided patterns into account" do
+    source =
+      "static inline int staticinlinefunc(struct my_struct *s)\n" + # 'normal' inline pattern
+      "{\n" +
+      "    return s->a;\n" +
+      "}\n" +
+      "static __inline__ int dummy_func_2(int a, char b, float c) {\n" + # First user pattern
+      "	c += 3.14;\n" +
+      "	b -= 32;\n" +
+      "	return a + (int)(b) + (int)c;\n" +
+      "}\n" +
+      "static __inline__ __attribute__ ((always_inline)) uint16_t attributealwaysinlinefuncname(void) {\n" + # Second user pattern
+      "	return (uint16_t)(42);\n" +
+      "}\n" +
+      "\n"
+
+    expected =
+      "int staticinlinefunc(struct my_struct *s);\n" +
+      "int dummy_func_2(int a, char b, float c);\n" +
+      "uint16_t attributealwaysinlinefuncname(void);\n" +
+      "\n"
+
+    @parser.treat_inlines = :include
+    @parser.inline_function_patterns = ['static __inline__ __attribute__ \(\(always_inline\)\)', 'static __inline__', 'static inline']
+    assert_equal(expected, @parser.transform_inline_functions(source))
+  end
+
+  it "Transform inline functions takes user provided patterns into account" do
+    source =
+      "static __inline__ __attribute__ ((always_inline)) uint16_t _somefunc (uint32_t a)\n" +
+      "{\n" +
+      "    return _someotherfunc (a);\n" +
+      "}\n" +
+      "static __inline__ uint16_t _somefunc_0  (uint32_t a)\n" +
+      "{\n" +
+      "    return (uint16_t) a;\n" +
+      "}\n" +
+      "\n"
+
+    expected =
+      "uint16_t _somefunc (uint32_t a);\n" +
+      "uint16_t _somefunc_0  (uint32_t a);\n" +
+      "\n"
+
+    @parser.treat_inlines = :include
+    @parser.inline_function_patterns = ['static __inline__ __attribute__ \(\(always_inline\)\)', 'static __inline__']
+    assert_equal(expected, @parser.transform_inline_functions(source))
+  end
+
 end

--- a/test/unit/cmock_header_parser_test.rb
+++ b/test/unit/cmock_header_parser_test.rb
@@ -2154,8 +2154,13 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
     assert_equal(expected, @parser.transform_inline_functions(source))
   end
 
-  it "Transform inline functions TODO" do
+  it "Transform inline functions limits deleting user macro to actual line/word" do
     source =
+      "#if defined (FORCE_INLINE)\n" +
+      "#define MY_LIBRARY_INLINE static __inline__ __attribute__ ((always_inline))\n" +
+      "#else\n" +
+      "#define MY_LIBRARY_INLINE\n" +
+      "#endif\n" +
       "#define INLINE static __inline__ __attribute__ ((always_inline))\n" +
       "#define INLINE_TWO \\\nstatic\\\ninline\n" +
       "INLINE uint16_t _somefunc (uint32_t a)\n" +
@@ -2177,13 +2182,16 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
       "#define INLINE_THREE \\\nstatic\\\ninline"
 
     expected =
+      "#if defined (FORCE_INLINE)\n" +
+      "#else\n" +
+      "#endif\n" +
       "uint16_t _somefunc (uint32_t a);\n" +
       "uint16_t _somefunc_0  (uint32_t a);\n" +
       "uint16_t _somefunc_1  (uint32_t a);\n" +
       "uint16_t _somefunc_2(uint32_t a);\n"
 
     @parser.treat_inlines = :include
-    @parser.inline_function_patterns = ['INLINE_THREE', 'INLINE_TWO', 'INLINE', 'static __inline__ __attribute__ \(\(always_inline\)\)', 'static __inline__']
+    @parser.inline_function_patterns = ['MY_LIBRARY_INLINE', 'INLINE_THREE', 'INLINE_TWO', 'INLINE', 'static __inline__ __attribute__ \(\(always_inline\)\)', 'static __inline__']
     assert_equal(expected, @parser.transform_inline_functions(source))
   end
 

--- a/test/unit/cmock_header_parser_test.rb
+++ b/test/unit/cmock_header_parser_test.rb
@@ -2154,4 +2154,37 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
     assert_equal(expected, @parser.transform_inline_functions(source))
   end
 
+  it "Transform inline functions TODO" do
+    source =
+      "#define INLINE static __inline__ __attribute__ ((always_inline))\n" +
+      "#define INLINE_TWO \\\nstatic\\\ninline\n" +
+      "INLINE uint16_t _somefunc (uint32_t a)\n" +
+      "{\n" +
+      "    return _someotherfunc (a);\n" +
+      "}\n" +
+      "static __inline__ uint16_t _somefunc_0  (uint32_t a)\n" +
+      "{\n" +
+      "    return (uint16_t) a;\n" +
+      "}\n" +
+      "static __inline__ __attribute__ \(\(always_inline\)\) uint16_t _somefunc_1  (uint32_t a)\n" +
+      "{\n" +
+      "    return (uint16_t) a;\n" +
+      "}\n" +
+      "INLINE_TWO uint16_t _somefunc_2(uint32_t a)\n" +
+      "{\n" +
+      "    return (uint16_t) a;\n" +
+      "}\n" +
+      "#define INLINE_THREE \\\nstatic\\\ninline"
+
+    expected =
+      "uint16_t _somefunc (uint32_t a);\n" +
+      "uint16_t _somefunc_0  (uint32_t a);\n" +
+      "uint16_t _somefunc_1  (uint32_t a);\n" +
+      "uint16_t _somefunc_2(uint32_t a);\n"
+
+    @parser.treat_inlines = :include
+    @parser.inline_function_patterns = ['INLINE_THREE', 'INLINE_TWO', 'INLINE', 'static __inline__ __attribute__ \(\(always_inline\)\)', 'static __inline__']
+    assert_equal(expected, @parser.transform_inline_functions(source))
+  end
+
 end

--- a/test/unit/cmock_header_parser_test.rb
+++ b/test/unit/cmock_header_parser_test.rb
@@ -2119,6 +2119,19 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
     assert_equal(expected, @parser.transform_inline_functions(source))
   end
 
+  it "Transform inline functions can handle header with only inline function declarations" do
+    source =
+      "static inline int dummy_func_decl(int a, char b, float c);\n" +
+      "\n"
+
+    expected =
+      "int dummy_func_decl(int a, char b, float c);\n" +
+      "\n"
+
+    @parser.treat_inlines = :include
+    assert_equal(expected, @parser.transform_inline_functions(source))
+  end
+
   it "Transform inline functions takes user provided patterns into account" do
     source =
       "static __inline__ __attribute__ ((always_inline)) uint16_t _somefunc (uint32_t a)\n" +


### PR DESCRIPTION
This fixes a series of bugs found in #265 but I failed to reproduce them at the time but with the help of @Letme and @davy79 (big thanks for the testing!), we were able to reproduce them in a small example project:
- inline function declarations were not recognized and handled incorrectly. The parsing assumed finding an inline function declaration was in fact a definition and removed the next function body between square brackets. But if it was a function declaration, the next square bracket body would be removed (which could be anything : struct body, next inline function ....). F.e. the code snippet below:
```
static inline int myfunc(void);

struct mystruct {
        int a;
};
```
Would result in:
```
int myfunc(void);

struct mystruct;

```
which is not what we want. This PR fixes this by recognizing function declarations and 'ignoring' them.
We do remove the inline pattern to end up with a regular function declaration, which causes no harm.
- Some users use something like the code fragment below and want to mock functions that have _INLINE in their declaration:
```
#ifdef INLINE
#define _INLINE static inline
#else
#define _INLINE
#endif
```
This also had some strange side effects that were not correct. This PR fixes this by removing the macro's with inline declaration pattern in them + fixes the cleanup of whitespaces after the inline function pattern. The cleanup of whitespaces would remove the first _INLINE macro correctly but would remove the ```#endif``` since  the parsing did a cleanup of whitespace-characters after a match:
```
#ifdef INLINE
#else
```
This is because a newline is a whitespace character in a ruby regex. So to fix this, use a 'space'-character class in the regex and search for word-boundaries as well. This has the desired effect:
```
#ifdef INLINE
#else
#endif
```
The macros are removed explicitly. This is debatable but I decided to remove them to get rid of all references to _INLINE (or whatever the user defined) in the mocked header.

FYI, my ruby is not great so if you want something changed/done differently, please let me know!