### PR TITLE
Deal with more complex array length expressions

### DIFF
--- a/lib/cmock_header_parser.rb
+++ b/lib/cmock_header_parser.rb
@@ -16,7 +16,7 @@ class CMockHeaderParser
     @c_calling_conventions = cfg.c_calling_conventions.uniq
     @treat_as_array = cfg.treat_as_array
     @treat_as_void = (['void'] + cfg.treat_as_void).uniq
-    @declaration_parse_matcher = /([\w\s\*\(\),\[\]]+??)\(([\w\s\*\(\),\.\[\]+-]*)\)$/m
+    @declaration_parse_matcher = /([\w\s\*\(\),\[\]]+??)\(([\w\s\*\(\),\.\[\]+\-\/]*)\)$/m
     @standards = (['int','short','char','long','unsigned','signed'] + cfg.treat_as.keys).uniq
     @array_size_name = cfg.array_size_name
     @array_size_type = (['int', 'size_t'] + cfg.array_size_type).uniq
@@ -359,7 +359,7 @@ class CMockHeaderParser
     else
       c = 0
       # magically turn brackets into asterisks, also match for parentheses that come from macros
-      arg_list.gsub!(/(\w+)(?:\s*\[[\s\w\(\)+-]*\])+/, '*\1')
+      arg_list.gsub!(/(\w+)(?:\s*\[[^\[\]]*\])+/, '*\1')
       # remove space to place asterisks with type (where they belong)
       arg_list.gsub!(/\s+\*/, '*')
       # pull asterisks away from arg to place asterisks with type (where they belong)

--- a/test/unit/cmock_header_parser_test.rb
+++ b/test/unit/cmock_header_parser_test.rb
@@ -1291,7 +1291,7 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
 
   it "handle arrays and treat them as pointers or strings" do
     source = 'void KeyOperated(CUSTOM_TYPE thing1[], int thing2 [ ], ' \
-             'char thing3 [][2 ][ 3], int* thing4[4], u8 thing5[((u8)5)])'
+             'char thing3 [][2 ][ 3], int* thing4[4], u8 thing5[((u8)((5 + 5*2)/3)])'
     expected_args = [
       { type: 'CUSTOM_TYPE*', name: 'thing1', ptr?: true,  const?: false, const_ptr?: false },
       { type: 'int*',         name: 'thing2', ptr?: true,  const?: false, const_ptr?: false },


### PR DESCRIPTION
Correctly parse array parameters where the array length is a mathematical expression.  Previously, the division sign (forward slash) in particular was causing trouble.