### PR TITLE
Cleaner implementation of Meson build support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,37 +1,32 @@
-###################################################################################
-#                                                                                 #
-# NAME: meson.build                                                               #
-#                                                                                 #
-# AUTHOR: Mike Karlesky, Mark VanderVoord, Greg Williams.                         #
-# WRITTEN BY: Michael Brockus.                                                    #
-#                                                                                 #
-# License: MIT                                                                    #
-#                                                                                 #
-###################################################################################
-
-
+#
+# build script written by : Michael Brockus.
+# github repo author: Mike Karlesky, Mark VanderVoord, Greg Williams.
+#
+# license: MIT
+#
 project('cmock', 'c',
-    license         : 'MIT',
-    meson_version   : '>=0.50.0',
+    license: 'MIT',
+    meson_version: '>=0.53.0',
     subproject_dir : 'vendor',
-    default_options: ['warning_level=3', 'werror=true', 'c_std=c11']
+    default_options: ['layout=flat', 'warning_level=3', 'werror=true', 'c_std=c11']
 )
 lang = 'c'
 cc = meson.get_compiler(lang)
 
 
-##
 #
 # Meson: Add compiler flags
 #
-##
 if cc.get_id() == 'clang'
     add_project_arguments(cc.get_supported_arguments(
             [
-                '-Wcast-qual', '-Wshadow', '-Wcast-align', '-Wweak-vtables',
-                '-Wold-style-cast', '-Wpointer-arith', '-Wconversion',
-                '-Wexit-time-destructors', '-Wglobal-constructors',
-                '-Wmissing-noreturn', '-Wmissing-prototypes', '-Wno-missing-braces'
+                '-Wexit-time-destructors',
+                '-Wglobal-constructors',
+                '-Wmissing-prototypes',
+                '-Wmissing-noreturn',
+                '-Wno-missing-braces',
+                '-Wold-style-cast', '-Wpointer-arith', '-Wweak-vtables',
+                '-Wcast-align', '-Wconversion', '-Wcast-qual', '-Wshadow'
             ]
         ), language: lang)
 endif
@@ -44,26 +39,15 @@ if cc.get_argument_syntax() == 'gcc'
                 '-Wno-parentheses'      , '-Wno-type-limits'             ,
                 '-Wformat-security'     , '-Wunreachable-code'           ,
                 '-Waggregate-return'    , '-Wformat-nonliteral'          ,
-                '-Wmissing-prototypes'  , '-Wold-style-definition'       ,
                 '-Wmissing-declarations', '-Wmissing-include-dirs'       ,
-                '-Wno-unused-parameter' , '-Wdeclaration-after-statement'
+                '-Wno-unused-parameter'
             ]
         ), language: lang)
 endif
-
-if cc.get_id() == 'msvc'
-    add_project_arguments(cc.get_supported_arguments(
-            [
-                '/w44265', '/w44061', '/w44062',
-                '/wd4018', '/wd4146', '/wd4244',
-                '/wd4305', '/D _CRT_SECURE_NO_WARNINGS'
-            ]
-        ), language: lang)
-endif
-
 
 unity_dep = dependency('unity', fallback: ['unity', 'unity_dep'])
 
+#
+# Sub directory to project source code
 subdir('src')
-
 cmock_dep = declare_dependency(link_with: cmock_lib, include_directories: cmock_dir)

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,14 +1,9 @@
-###################################################################################
-#                                                                                 #
-# NAME: meson.build                                                               #
-#                                                                                 #
-# AUTHOR: Mike Karlesky, Mark VanderVoord, Greg Williams.                         #
-# WRITTEN BY: Michael Brockus.                                                    #
-#                                                                                 #
-# License: MIT                                                                    #
-#                                                                                 #
-###################################################################################
-
+#
+# build script written by : Michael Brockus.
+# github repo author: Mike Karlesky, Mark VanderVoord, Greg Williams.
+#
+# license: MIT
+#
 cmock_dir = include_directories('.')
 
 cmock_lib = static_library(meson.project_name(), 


### PR DESCRIPTION
Provided updated comment blocks, bump meson minimum required version to 0.53.0 to match PR from Unity where I did that because of better support for embedded systems and improved static linking.