### PR TITLE
cmock_generator_plugin_callback: allow usage with Clang scan-build

### DIFF
--- a/lib/cmock_generator_plugin_callback.rb
+++ b/lib/cmock_generator_plugin_callback.rb
@@ -82,7 +82,9 @@ class CMockGeneratorPluginCallback
 
   def mock_verify(function)
     func_name = function[:name]
-    "  if (Mock.#{func_name}_CallbackFunctionPointer != NULL)\n    call_instance = CMOCK_GUTS_NONE;\n"
+    "  if (Mock.#{func_name}_CallbackFunctionPointer != NULL)\n  {\n" \
+    "    call_instance = CMOCK_GUTS_NONE;\n" \
+    "    (void)call_instance;\n  }\n"
   end
 
 end


### PR DESCRIPTION
Running a project through Clang's scan-build produces countless
warnings like

build/test/mocks/mock_handleTroubleEvents.c:321:5: warning: Value stored to 'call_instance' is never read
    call_instance = CMOCK_GUTS_NONE;
    ^               ~~~~~~~~~~~~~~~

scan-build correctly determines that in the following snippet

    UNITY_CLR_DETAILS();
    if (Mock.checkForActiveTroubleAfterDebounce_CallbackFunctionPointer != NULL)
      call_instance = CMOCK_GUTS_NONE;
    call_instance = Mock.startStopTimer_CallInstance;

as generated by Ceedling / CMock, the first assignment to
call_instance is completely unused.

The sheer amount of warnings makes it very hard to impossible to
spot real problems in one's code, and creates huge code analysis
reports that just distract from actual problems in one's code.

Without being too invasive, we can instruct scan-build to ignore
this dead store using
    https://clang-analyzer.llvm.org/faq.html#dead_store

Signed-off-by: André Draszik <git@andred.net>