### PR TITLE
Add support for mocking C++ static class member methods

### DIFF
--- a/docs/CMock_Summary.md
+++ b/docs/CMock_Summary.md
@@ -748,6 +748,32 @@ themselves. Call it during a test to have CMock validate everything to this poin
 and start over clean. This is really useful when wanting to test a function in
 an iterative manner with different arguments.
 
+C++ Support
+---------
+C++ unit test/mocking frameworks often use a completely different approach (vs. CMock) that relies on overloading virtual class members and does not support directly mocking static class member methods or free functions (i.e., functions in plain C). One workaround is to wrap the non-virtual functions in an object that exposes them as virtual methods and modify your code to inject mocks at run-time … but there is another way!
+
+Simply use CMock to mock the static member methods and a C++ mocking framework to handle the virtual methods. (Yes, you can mix mocks from CMock and a C++ mocking framework together in the same test!)
+
+Keep in mind that since C++ mocking frameworks often link the real object to the unit test too, we need to resolve multiple definition errors with something like the following in the source of the real implementation for any functions that CMock mocks:
+
+    #if defined(TEST)
+        __attribute__((weak))
+    #endif
+
+To address potential issues with re-using the same function name in different namespaces/classes, the generated function names include the namespace(s) and class. For example:
+
+    namespace MyNamespace {
+        class MyClass {
+            static int DoesSomething(int a, int b);
+        };
+    }
+
+Will generate functions like
+
+    void MyNamespace_MyClass_DoesSomething_ExpectAndReturn(int a, int b, int toReturn);
+
+NOTE: The current implementation does support references as return types but not as arguments.
+
 Examples
 ========
 

--- a/lib/cmock_generator.rb
+++ b/lib/cmock_generator.rb
@@ -66,9 +66,7 @@ class CMockGenerator
   end
 
   def create_using_statement(file, function)
-    if function[:namespace].length > 0
-      file << "using namespace #{function[:namespace].join('::')};\n"
-    end
+    file << "using namespace #{function[:namespace].join('::')};\n" unless function[:namespace].empty?
   end
 
   def create_mock_header_file(parsed_stuff)
@@ -272,7 +270,7 @@ class CMockGenerator
     end
 
     # Determine class prefix (if any)
-    cls_pre = ""
+    cls_pre = ''
     unless function[:class].nil?
       cls_pre = "#{function[:class]}::"
     end
@@ -307,7 +305,7 @@ class CMockGenerator
     file << "}\n"
 
     # Close any namespace(s) opened above
-    function[:namespace].each do |ns|
+    function[:namespace].each do
       file << "}\n"
     end
 

--- a/lib/cmock_generator_plugin_callback.rb
+++ b/lib/cmock_generator_plugin_callback.rb
@@ -85,4 +85,11 @@ class CMockGeneratorPluginCallback
     "    call_instance = CMOCK_GUTS_NONE;\n" \
     "    (void)call_instance;\n  }\n"
   end
+
+  def mock_destroy(function)
+    func_name = function[:name]
+    "  Mock.#{func_name}_CallbackBool = 0;\n" \
+    "  Mock.#{func_name}_CallbackFunctionPointer = NULL;\n" \
+    "  Mock.#{func_name}_CallbackCalls = 0;\n"
+  end
 end

--- a/lib/cmock_generator_plugin_expect.rb
+++ b/lib/cmock_generator_plugin_expect.rb
@@ -30,9 +30,9 @@ class CMockGeneratorPluginExpect
       lines << "  #{function[:return][:type].chomp('&')} ReturnRefVal;\n"
       lines << "  std::reference_wrapper<#{function[:return][:type].chomp('&')}> ReturnVal = ReturnRefVal;\n"
     else
-      lines << "  #{function[:return][:type]} ReturnVal;\n"  unless function[:return][:void?]
+      lines << "  #{function[:return][:type]} ReturnVal;\n" unless function[:return][:void?]
     end
-    lines << "  int CallOrder;\n"                          if @ordered
+    lines << "  int CallOrder;\n" if @ordered
     function[:args].each do |arg|
       lines << "  #{arg[:type]} Expected_#{arg[:name]};\n"
     end

--- a/lib/cmock_generator_plugin_expect.rb
+++ b/lib/cmock_generator_plugin_expect.rb
@@ -25,7 +25,13 @@ class CMockGeneratorPluginExpect
 
   def instance_typedefs(function)
     lines = ''
-    lines << "  #{function[:return][:type]} ReturnVal;\n"  unless function[:return][:void?]
+    if function[:return][:type].end_with?('&')
+      # Handle C++ reference return type differently
+      lines << "  #{function[:return][:type].chomp('&')} ReturnRefVal;\n"
+      lines << "  std::reference_wrapper<#{function[:return][:type].chomp('&')}> ReturnVal = ReturnRefVal;\n"
+    else
+      lines << "  #{function[:return][:type]} ReturnVal;\n"  unless function[:return][:void?]
+    end
     lines << "  int CallOrder;\n"                          if @ordered
     function[:args].each do |arg|
       lines << "  #{arg[:type]} Expected_#{arg[:name]};\n"

--- a/lib/cmock_generator_plugin_ignore.rb
+++ b/lib/cmock_generator_plugin_ignore.rb
@@ -17,6 +17,8 @@ class CMockGeneratorPluginIgnore
   def instance_structure(function)
     if function[:return][:void?]
       "  int #{function[:name]}_IgnoreBool;\n"
+    elsif function[:return][:type].end_with?('&') # C++ reference
+      "  int #{function[:name]}_IgnoreBool;\n  #{function[:return][:type].chomp('&')} #{function[:name]}_FinalRefReturn;\n  std::reference_wrapper<#{function[:return][:type].chomp('&')}> #{function[:name]}_FinalReturn = #{function[:name]}_FinalRefReturn;\n"
     else
       "  int #{function[:name]}_IgnoreBool;\n  #{function[:return][:type]} #{function[:name]}_FinalReturn;\n"
     end

--- a/lib/cmock_generator_utils.rb
+++ b/lib/cmock_generator_utils.rb
@@ -69,7 +69,7 @@ class CMockGeneratorUtils
   end
 
   def code_assign_argument_quickly(dest, arg)
-    if (arg[:ptr?] || @treat_as.include?(arg[:type]) || arg[:type].end_with?('&'))
+    if arg[:ptr?] || @treat_as.include?(arg[:type]) || arg[:type].end_with?('&')
       "  #{dest} = #{arg[:name]};\n"
     else
       assert_expr = "sizeof(#{arg[:name]}) == sizeof(#{arg[:type]}) ? 1 : -1"

--- a/lib/cmock_generator_utils.rb
+++ b/lib/cmock_generator_utils.rb
@@ -69,7 +69,7 @@ class CMockGeneratorUtils
   end
 
   def code_assign_argument_quickly(dest, arg)
-    if arg[:ptr?] || @treat_as.include?(arg[:type])
+    if (arg[:ptr?] || @treat_as.include?(arg[:type]) || arg[:type].end_with?('&'))
       "  #{dest} = #{arg[:name]};\n"
     else
       assert_expr = "sizeof(#{arg[:name]}) == sizeof(#{arg[:type]}) ? 1 : -1"

--- a/lib/cmock_header_parser.rb
+++ b/lib/cmock_header_parser.rb
@@ -15,7 +15,7 @@ class CMockHeaderParser
     @c_calling_conventions = cfg.c_calling_conventions.uniq
     @treat_as_array = cfg.treat_as_array
     @treat_as_void = (['void'] + cfg.treat_as_void).uniq
-    @function_declaration_parse_base_match = '([\w\s\*\(\),\[\]]+??)\(([\w\s\*\(\),\.\[\]+\-\/]*)\)'
+    @function_declaration_parse_base_match = '([\w\s\*&\(\),\[\]]+??)\(([\w\s\*\(\),\.\[\]+\-\/]*)\)'
     @declaration_parse_matcher = /#{@function_declaration_parse_base_match}$/m
     @standards = (%w[int short char long unsigned signed] + cfg.treat_as.keys).uniq
     @array_size_name = cfg.array_size_name
@@ -37,8 +37,10 @@ class CMockHeaderParser
     @normalized_source = nil
     function_names = []
 
-    parse_functions(import_source(source)).map do |decl|
-      func = parse_declaration(decl)
+    all_funcs = parse_functions( import_source(source) ).map {|item| [item]}
+    all_funcs += parse_cpp_functions( import_source(source, cpp=true) )
+    all_funcs.map do |decl|
+      func = parse_declaration(*decl)
       unless function_names.include? func[:name]
         @funcs << func
         function_names << func[:name]
@@ -180,7 +182,7 @@ class CMockHeaderParser
     source
   end
 
-  def import_source(source)
+  def import_source(source, cpp=false)
     # let's clean up the encoding in case they've done anything weird with the characters we might find
     source = source.force_encoding('ISO-8859-1').encode('utf-8', :replace => nil)
 
@@ -222,7 +224,10 @@ class CMockHeaderParser
     # forward declared structs are removed before struct definitions so they don't mess up real thing later. we leave structs keywords in function prototypes
     source.gsub!(/^[\w\s]*struct[^;\{\}\(\)]+;/m, '')                                      # remove forward declared structs
     source.gsub!(/^[\w\s]*(enum|union|struct|typedef)[\w\s]*\{[^\}]+\}[\w\s\*\,]*;/m, '')  # remove struct, union, and enum definitions and typedefs with braces
-    source.gsub!(/(\W)(?:register|auto|static|restrict)(\W)/, '\1\2')                      # remove problem keywords
+    # remove problem keywords
+    source.gsub!(/(\W)(?:register|auto|restrict)(\W)/, '\1\2')
+    source.gsub!(/(\W)(?:static)(\W)/, '\1\2') unless cpp
+
     source.gsub!(/\s*=\s*['"a-zA-Z0-9_\.]+\s*/, '')                                        # remove default value statements from argument lists
     source.gsub!(/^(?:[\w\s]*\W)?typedef\W[^;]*/m, '')                                     # remove typedef statements
     source.gsub!(/\)(\w)/, ') \1')                                                         # add space between parenthese and alphanumeric
@@ -234,11 +239,13 @@ class CMockHeaderParser
     # scan for functions which return function pointers, because they are a pain
     source.gsub!(/([\w\s\*]+)\(*\(\s*\*([\w\s\*]+)\s*\(([\w\s\*,]*)\)\)\s*\(([\w\s\*,]*)\)\)*/) do |_m|
       functype = "cmock_#{@module_name}_func_ptr#{@typedefs.size + 1}"
-      @typedefs << "typedef #{Regexp.last_match(1).strip}(*#{functype})(#{Regexp.last_match(4)});"
-      "#{functype} #{Regexp.last_match(2).strip}(#{Regexp.last_match(3)});"
+      unless cpp # only collect once
+        @typedefs << "typedef #{Regexp.last_match(1).strip}(*#{functype})(#{Regexp.last_match(4)});"
+        "#{functype} #{Regexp.last_match(2).strip}(#{Regexp.last_match(3)});"
+      end
     end
 
-    source = remove_nested_pairs_of_braces(source)
+    source = remove_nested_pairs_of_braces(source) unless cpp
 
     if @treat_inlines == :include
       # Functions having "{ }" at this point are/were inline functions,
@@ -257,7 +264,8 @@ class CMockHeaderParser
     source.gsub!(/\s+/, ' ')          # remove remaining extra white space
 
     # split lines on semicolons and remove things that are obviously not what we are looking for
-    src_lines = source.split(/\s*;\s*/).uniq
+    src_lines = source.split(/\s*;\s*/)
+    src_lines = src_lines.uniq unless cpp # must retain closing braces for class/namespace
     src_lines.delete_if { |line| line.strip.empty? } # remove blank lines
     src_lines.delete_if { |line| !(line =~ /[\w\s\*]+\(+\s*\*[\*\s]*[\w\s]+(?:\[[\w\s]*\]\s*)+\)+\s*\((?:[\w\s\*]*,?)*\s*\)/).nil? } # remove function pointer arrays
 
@@ -270,6 +278,55 @@ class CMockHeaderParser
     end
 
     src_lines.delete_if(&:empty?) # drop empty lines
+  end
+
+  # Rudimentary C++ parser - does not handle all situations - e.g.:
+  #  * A namespace function appears after a class with private members (should be parsed)
+  #  * Anonymous namespace (shouldn't parse anything - no matter how nested - within it)
+  #  * A class nested within another class
+  def parse_cpp_functions(source)
+    funcs = []
+
+    ns = []
+    pub = false
+    source.each do |line|
+      # Search for namespace, class, opening and closing braces
+      line.scan(/(?:(?:\b(?:namespace|class)\s+(?:\S+)\s*)?{)|}/).each do |item|
+        if '}' == item
+          ns.pop
+        else
+          token = item.strip.sub(/\s+/, ' ')
+          ns << token
+
+          pub = false if token.start_with? 'class'
+          pub = true if token.start_with? 'namespace'
+        end
+      end
+
+      pub = true if line =~ /public:/
+      pub = false if line =~ /private:/ or line =~ /protected:/
+
+      # ignore non-public and non-static
+      next unless pub
+      next unless line =~ /\bstatic\b/
+
+      line.sub!(/^.*static/, '')
+      if (line =~ @declaration_parse_matcher)
+        tmp = ns.reject{ |item| item == '{'}
+
+        # Identify class name, if any
+        cls = nil
+        if tmp[-1].start_with? "class "
+          cls = tmp.pop.sub(/class (\S+) {/, '\1')
+        end
+
+        # Assemble list of namespaces
+        tmp.each{ |item| item.sub!(/(?:namespace|class) (\S+) {/, '\1') }
+
+        funcs << [line.strip.gsub(/\s+/, ' '), tmp, cls]
+      end
+    end
+    return funcs
   end
 
   def parse_functions(source)
@@ -442,8 +499,10 @@ class CMockHeaderParser
     end
   end
 
-  def parse_declaration(declaration)
+  def parse_declaration(declaration, namespace=[], classname=nil)
     decl = {}
+    decl[:namespace] = namespace
+    decl[:class] = classname
 
     regex_match = @declaration_parse_matcher.match(declaration)
     raise "Failed parsing function declaration: '#{declaration}'" if regex_match.nil?
@@ -454,7 +513,19 @@ class CMockHeaderParser
     # process function attributes, return type, and name
     parsed = parse_type_and_name(regex_match[1])
 
-    decl[:name] = parsed[:name]
+    # Record original name without scope prefix
+    decl[:orig_name] = parsed[:name]
+
+    # Prefix name with namespace scope (if any) and then class
+    decl[:name] = namespace.join('_')
+    unless classname.nil?
+      decl[:name] << "_" unless decl[:name].length == 0
+      decl[:name] << classname
+    end
+    # Add original name to complete fully scoped name
+    decl[:name] << "_" unless decl[:name].length == 0
+    decl[:name] << decl[:orig_name]
+
     decl[:modifier] = parsed[:modifier]
     unless parsed[:c_calling_convention].nil?
       decl[:c_calling_convention] = parsed[:c_calling_convention]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,6 +26,7 @@ def test_return
   {
     :int     => {:type => "int",         :name => 'cmock_to_return', :ptr? => false, :const? => false, :void? => false, :str => 'int cmock_to_return'},
     :int_ptr => {:type => "int*",        :name => 'cmock_to_return', :ptr? => true,  :const? => false, :void? => false, :str => 'int* cmock_to_return'},
+    :int_ref => {:type => "int&",        :name => 'cmock_to_return', :ptr? => true,  :const? => false, :void? => false, :str => 'int& cmock_to_return'},
     :void    => {:type => "void",        :name => 'cmock_to_return', :ptr? => false, :const? => false, :void? => true,  :str => 'void cmock_to_return'},
     :string  => {:type => "const char*", :name => 'cmock_to_return', :ptr? => false, :const? => true,  :void? => false, :str => 'const char* cmock_to_return'},
   }
@@ -35,6 +36,7 @@ def test_arg
   {
     :int        => {:type => "int",         :name => 'MyInt',       :ptr? => false, :const? => false, :const_ptr? => false},
     :int_ptr    => {:type => "int*",        :name => 'MyIntPtr',    :ptr? => true,  :const? => false, :const_ptr? => false},
+    :int_ref    => {:type => "int&",        :name => 'MyIntRef',    :ptr? => true,  :const? => false, :const_ptr? => false},
     :const_ptr  => {:type => "int*",        :name => 'MyConstPtr',  :ptr? => true,  :const? => false, :const_ptr? => true},
     :double_ptr => {:type => "int const**", :name => 'MyDoublePtr', :ptr? => true,  :const? => true,  :const_ptr? => false},
     :mytype     => {:type => "MY_TYPE",     :name => 'MyMyType',    :ptr? => false, :const? => true,  :const_ptr? => false},

--- a/test/unit/cmock_generator_main_test.rb
+++ b/test/unit/cmock_generator_main_test.rb
@@ -325,6 +325,9 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
                  "#include <string.h>\n",
                  "#include <stdlib.h>\n",
                  "#include <setjmp.h>\n",
+                 "#ifdef __cplusplus\n",
+                 "#include <functional>\n",
+                 "#endif\n",
                  "#include \"cmock.h\"\n",
                  "#include \"MockPoutPoutFish.h\"\n",
                  "\n",
@@ -460,7 +463,6 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
     output = []
     expected = [ "void MockPoutPoutFish_Destroy(void)\n{\n",
                  "  CMock_Guts_MemFreeAll();\n",
-                 "  memset(&Mock, 0, sizeof(Mock));\n",
                  "}\n\n"
                ]
 
@@ -476,7 +478,8 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
     output = []
     expected = [ "void MockPoutPoutFish_Destroy(void)\n{\n",
                  "  CMock_Guts_MemFreeAll();\n",
-                 "  memset(&Mock, 0, sizeof(Mock));\n",
+                 "  memset(&Mock.First_CallInstance, 0, sizeof(Mock.First_CallInstance));\n",
+                 "  memset(&Mock.Second_CallInstance, 0, sizeof(Mock.Second_CallInstance));\n",
                  "  uno",
                  "  GlobalExpectCount = 0;\n",
                  "  GlobalVerifyOrder = 0;\n",
@@ -497,6 +500,9 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
                  :args => ["uint32 sandwiches", "const char* named"],
                  :var_arg => nil,
                  :name => "SupaFunction",
+                 :orig_name => "SupaFunction",
+                 :namespace => [],
+                 :class => nil,
                  :attributes => "__inline"
                }
     output = []
@@ -532,6 +538,9 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
                  :args => ["uint32 sandwiches"],
                  :var_arg => "corn ...",
                  :name => "SupaFunction",
+                 :orig_name => "SupaFunction",
+                 :namespace => [],
+                 :class => nil,
                  :attributes => nil
                }
     output = []
@@ -557,5 +566,124 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
     @cmock_generator.create_mock_implementation(output, function)
 
     assert_equal(expected.join, output.join)
+  end
+
+  it "create mock implementation function in source file for C++ static member" do
+    function = { :modifier => "static",
+                 :return => test_return[:int],
+                 :args_string => "uint32 sandwiches, const char* named",
+                 :args => ["uint32 sandwiches", "const char* named"],
+                 :var_arg => nil,
+                 :orig_name => "SupaFunction",
+                 :namespace => ["ns1", "ns2"],
+                 :class => "SupaClass",
+                 :name => "ns1_ns2_SupaClass_SupaFunction",
+                 :attributes => nil
+               }
+    output = []
+    expected = [ "namespace ns1 {\n",
+                 "namespace ns2 {\n",
+                 "static int SupaClass::SupaFunction(uint32 sandwiches, const char* named)\n",
+                 "{\n",
+                 "  UNITY_LINE_TYPE cmock_line = TEST_LINE_NUM;\n",
+                 "  CMOCK_ns1_ns2_SupaClass_SupaFunction_CALL_INSTANCE* cmock_call_instance;\n",
+                 "  UNITY_SET_DETAIL(CMockString_ns1_ns2_SupaClass_SupaFunction);\n",
+                 "  cmock_call_instance = (CMOCK_ns1_ns2_SupaClass_SupaFunction_CALL_INSTANCE*)CMock_Guts_GetAddressFor(Mock.ns1_ns2_SupaClass_SupaFunction_CallInstance);\n",
+                 "  Mock.ns1_ns2_SupaClass_SupaFunction_CallInstance = CMock_Guts_MemNext(Mock.ns1_ns2_SupaClass_SupaFunction_CallInstance);\n",
+                 "  uno",
+                 "  UNITY_TEST_ASSERT_NOT_NULL(cmock_call_instance, cmock_line, CMockStringCalledMore);\n",
+                 "  cmock_line = cmock_call_instance->LineNumber;\n",
+                 "  dos",
+                 "  tres",
+                 "  UNITY_CLR_DETAILS();\n",
+                 "  return cmock_call_instance->ReturnVal;\n",
+                 "}\n",
+                 "}\n",
+                 "}\n\n",
+               ]
+    @plugins.expect :run, ["  uno"],          [:mock_implementation_precheck, function]
+    @plugins.expect :run, ["  dos","  tres"], [:mock_implementation, function]
+
+    @cmock_generator.create_mock_implementation(output, function)
+
+    assert_equal(expected.join, output.join)
+  end
+
+  it "create mock implementation functions in source file with different options" do
+    function = { :modifier => "",
+                 :c_calling_convention => "__stdcall",
+                 :return => test_return[:int],
+                 :args_string => "uint32 sandwiches",
+                 :args => ["uint32 sandwiches"],
+                 :var_arg => "corn ...",
+                 :name => "SupaFunction",
+                 :orig_name => "SupaFunction",
+                 :namespace => [],
+                 :class => nil,
+                 :attributes => nil
+               }
+    output = []
+    expected = [ "int __stdcall SupaFunction(uint32 sandwiches, corn ...)\n",
+                 "{\n",
+                 "  UNITY_LINE_TYPE cmock_line = TEST_LINE_NUM;\n",
+                 "  CMOCK_SupaFunction_CALL_INSTANCE* cmock_call_instance;\n",
+                 "  UNITY_SET_DETAIL(CMockString_SupaFunction);\n",
+                 "  cmock_call_instance = (CMOCK_SupaFunction_CALL_INSTANCE*)CMock_Guts_GetAddressFor(Mock.SupaFunction_CallInstance);\n",
+                 "  Mock.SupaFunction_CallInstance = CMock_Guts_MemNext(Mock.SupaFunction_CallInstance);\n",
+                 "  uno",
+                 "  UNITY_TEST_ASSERT_NOT_NULL(cmock_call_instance, cmock_line, CMockStringCalledMore);\n",
+                 "  cmock_line = cmock_call_instance->LineNumber;\n",
+                 "  dos",
+                 "  tres",
+                 "  UNITY_CLR_DETAILS();\n",
+                 "  return cmock_call_instance->ReturnVal;\n",
+                 "}\n\n"
+               ]
+    @plugins.expect :run, ["  uno"],          [:mock_implementation_precheck, function]
+    @plugins.expect :run, ["  dos","  tres"], [:mock_implementation, function]
+
+    @cmock_generator.create_mock_implementation(output, function)
+
+    assert_equal(expected.join, output.join)
+  end
+
+  it "creates using statements for C++ static member in namespace" do
+    function = { :modifier => "static",
+                 :return => test_return[:int],
+                 :args_string => "uint32 sandwiches",
+                 :args => ["uint32 sandwiches"],
+                 :var_arg => nil,
+                 :orig_name => "SupaFunction",
+                 :namespace => ["ns1"],
+                 :class => "SupaClass",
+                 :name => "ns1_SupaClass_SupaFunction",
+                 :attributes => nil
+               }
+    output = []
+    expected = "using namespace ns1;\n"
+
+    @cmock_generator.create_using_statement(output, function)
+
+    assert_equal(expected, output.join)
+  end
+
+  it "creates using statements for C++ static member in nested namespace" do
+    function = { :modifier => "static",
+                 :return => test_return[:int],
+                 :args_string => "uint32 sandwiches",
+                 :args => ["uint32 sandwiches"],
+                 :var_arg => nil,
+                 :orig_name => "SupaFunction",
+                 :namespace => ["ns1", "ns2"],
+                 :class => "SupaClass",
+                 :name => "ns1_ns2_SupaClass_SupaFunction",
+                 :attributes => nil
+               }
+    output = []
+    expected = "using namespace ns1::ns2;\n"
+
+    @cmock_generator.create_using_statement(output, function)
+
+    assert_equal(expected, output.join)
   end
 end

--- a/test/unit/cmock_generator_plugin_callback_test.rb
+++ b/test/unit/cmock_generator_plugin_callback_test.rb
@@ -278,4 +278,14 @@ describe CMockGeneratorPluginCallback, "Verify CMockGeneratorPluginCallback Modu
     returned = @cmock_generator_plugin_callback.mock_interfaces(function)
     assert_equal(expected, returned)
   end
+
+  it "add mock destruction for function" do
+    function = {:name => "Apple", :args => [], :args_string => "void", :return => test_return[:int]}
+    expected = ["  Mock.Apple_CallbackBool = 0;\n",
+                "  Mock.Apple_CallbackFunctionPointer = NULL;\n",
+                "  Mock.Apple_CallbackCalls = 0;\n"
+               ].join
+    returned = @cmock_generator_plugin_callback.mock_destroy(function)
+    assert_equal(expected, returned)
+  end
 end

--- a/test/unit/cmock_generator_plugin_expect_a_test.rb
+++ b/test/unit/cmock_generator_plugin_expect_a_test.rb
@@ -62,6 +62,15 @@ describe CMockGeneratorPluginExpect, "Verify CMockGeneratorPluginExpect Module W
     assert_equal(expected, returned)
   end
 
+  it "add to typedef structure mock needs of functions of with C++ reference return type" do
+    function = {:name => "Elm", :args => [], :return => test_return[:int_ref]}
+    expected = ["  int ReturnRefVal;\n",
+                "  std::reference_wrapper<int> ReturnVal = ReturnRefVal;\n"
+               ].join
+    returned = @cmock_generator_plugin_expect.instance_typedefs(function)
+    assert_equal(expected, returned)
+  end
+
   it "add mock function declaration for functions of style 'void func(void)'" do
     function = {:name => "Maple", :args => [], :return => test_return[:void]}
     expected = "#define Maple_Expect() Maple_CMockExpect(__LINE__)\n" +

--- a/test/unit/cmock_generator_plugin_expect_b_test.rb
+++ b/test/unit/cmock_generator_plugin_expect_b_test.rb
@@ -62,6 +62,16 @@ describe CMockGeneratorPluginExpect, "Verify CMockGeneratorPluginExpect Module w
     assert_equal(expected, returned)
   end
 
+  it "add to typedef structure mock needs of functions of with C++ reference return type" do
+    function = {:name => "Elm", :args => [], :return => test_return[:int_ref]}
+    expected = ["  int ReturnRefVal;\n",
+                "  std::reference_wrapper<int> ReturnVal = ReturnRefVal;\n",
+                "  int CallOrder;\n"
+               ].join
+    returned = @cmock_generator_plugin_expect.instance_typedefs(function)
+    assert_equal(expected, returned)
+  end
+
   it "add mock function declaration for functions of style 'void func(void)'" do
     function = {:name => "Maple", :args => [], :return => test_return[:void]}
     expected = "#define Maple_Expect() Maple_CMockExpect(__LINE__)\n" +

--- a/test/unit/cmock_generator_plugin_ignore_test.rb
+++ b/test/unit/cmock_generator_plugin_ignore_test.rb
@@ -33,6 +33,25 @@ describe CMockGeneratorPluginIgnore, "Verify CMockGeneratorPluginIgnore Module" 
     assert_equal(expected, returned)
   end
 
+  it "add required variables to the instance structure for simple non-void return type" do
+    function = {:name => "Grass", :args => [], :return => test_return[:int]}
+    expected = ["  int Grass_IgnoreBool;\n",
+                "  int Grass_FinalReturn;\n"
+               ].join
+    returned = @cmock_generator_plugin_ignore.instance_structure(function)
+    assert_equal(expected, returned)
+  end
+
+  it "add required variables to the instance structure for C++ reference return type" do
+    function = {:name => "Grass", :args => [], :return => test_return[:int_ref]}
+    expected = ["  int Grass_IgnoreBool;\n",
+                "  int Grass_FinalRefReturn;\n",
+                "  std::reference_wrapper<int> Grass_FinalReturn = Grass_FinalRefReturn;\n"
+               ].join
+    returned = @cmock_generator_plugin_ignore.instance_structure(function)
+    assert_equal(expected, returned)
+  end
+
   it "handle function declarations for functions without return values" do
     function = {:name => "Mold", :args_string => "void", :return => test_return[:void]}
     expected = "#define Mold_Ignore() Mold_CMockIgnore()\nvoid Mold_CMockIgnore(void);\n"

--- a/test/unit/cmock_generator_utils_test.rb
+++ b/test/unit/cmock_generator_utils_test.rb
@@ -398,4 +398,12 @@ describe CMockGeneratorUtils, "Verify CMockGeneratorUtils Module" do
     @unity_helper.expect :get_helper, ['UNITY_TEST_ASSERT_EQUAL_MY_TYPE_ARRAY', '&'], ['MY_TYPE']
     assert_equal(expected, @cmock_generator_utils_complex.code_verify_an_arg_expectation(function, arg))
   end
+
+  it 'handle C++ reference like a pointer in regards to copying/assigning (in code_assign_argument_quickly)' do
+    dest     = 'somewhereWarm'
+    arg      = test_arg[:int_ref]
+    expected = "  somewhereWarm = MyIntRef;\n"
+    output = @cmock_generator_utils_simple.code_assign_argument_quickly(dest, arg)
+    assert_equal(expected, output)
+  end
 end

--- a/test/unit/cmock_header_parser_test.rb
+++ b/test/unit/cmock_header_parser_test.rb
@@ -577,6 +577,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
     source = "MY_FUNKY_VOID FunkyVoidReturned(int a)"
     expected = { :var_arg=>nil,
                  :name=>"FunkyVoidReturned",
+                 :orig_name=>"FunkyVoidReturned",
+                 :namespace=>[],
+                 :class=>nil,
                  :return=>{ :type   => "void",
                             :name   => 'cmock_to_return',
                             :ptr?   => false,
@@ -597,6 +600,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
     source = "int FunkyVoidAsArg(MY_FUNKY_VOID)"
     expected = { :var_arg=>nil,
                  :name=>"FunkyVoidAsArg",
+                 :orig_name=>"FunkyVoidAsArg",
+                 :namespace=>[],
+                 :class=>nil,
                  :return=>{ :type   => "int",
                             :name   => 'cmock_to_return',
                             :ptr?   => false,
@@ -617,6 +623,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
     source = "char FunkyVoidPointer(MY_FUNKY_VOID* bluh)"
     expected = { :var_arg=>nil,
                  :name=>"FunkyVoidPointer",
+                 :orig_name=>"FunkyVoidPointer",
+                 :namespace=>[],
+                 :class=>nil,
                  :return=>{ :type   => "char",
                             :name   => 'cmock_to_return',
                             :ptr?   => false,
@@ -716,6 +725,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
     source = "int Foo(int a, unsigned int b)"
     expected = { :var_arg=>nil,
                  :name=>"Foo",
+                 :orig_name=>"Foo",
+                 :namespace=>[],
+                 :class=>nil,
                  :return=>{ :type   => "int",
                             :name   => 'cmock_to_return',
                             :ptr?   => false,
@@ -747,6 +759,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                             :void?  => true
                           },
                  :name=>"FunkyChicken",
+                 :orig_name=>"FunkyChicken",
+                 :namespace=>[],
+                 :class=>nil,
                  :modifier=>"",
                  :contains_ptr? => false,
                  :args=>[ {:type=>"uint", :name=>"la", :ptr? => false, :const? => false, :const_ptr? => false},
@@ -771,6 +786,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                             :void?  => true
                           },
                  :name=>"tat",
+                 :orig_name=>"tat",
+                 :namespace=>[],
+                 :class=>nil,
                  :modifier=>"",
                  :contains_ptr? => false,
                  :args=>[ ],
@@ -792,6 +810,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                             :void?  => false
                           },
                  :name=>"TheMatrix",
+                 :orig_name=>"TheMatrix",
+                 :namespace=>[],
+                 :class=>nil,
                  :modifier=>"const",
                  :contains_ptr? => true,
                  :args=>[ {:type=>"int",           :name=>"Trinity", :ptr? => false, :const? => false, :const_ptr? => false},
@@ -815,6 +836,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                             :void?  => false
                           },
                  :name=>"TheMatrix",
+                 :orig_name=>"TheMatrix",
+                 :namespace=>[],
+                 :class=>nil,
                  :modifier=>"const",
                  :c_calling_convention=>"__stdcall",
                  :contains_ptr? => true,
@@ -824,6 +848,32 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                  :args_string=>"int Trinity, unsigned int* Neo",
                  :args_call=>"Trinity, Neo" }
     assert_equal(expected, @parser.parse_declaration(source))
+  end
+
+  it "extract and return function declarations inside namespace and class" do
+
+    source = "int Foo(int a, unsigned int b)"
+    expected = { :var_arg=>nil,
+                 :name=>"ns1_ns2_Bar_Foo",
+                 :orig_name=>"Foo",
+                 :class=>"Bar",
+                 :namespace=>["ns1", "ns2"],
+                 :return=>{ :type   => "int",
+                            :name   => 'cmock_to_return',
+                            :ptr?   => false,
+                            :const? => false,
+                            :const_ptr? => false,
+                            :str    => "int cmock_to_return",
+                            :void?  => false
+                          },
+                 :modifier=>"",
+                 :contains_ptr? => false,
+                 :args=>[ {:type=>"int", :name=>"a", :ptr? => false, :const? => false, :const_ptr? => false},
+                          {:type=>"unsigned int", :name=>"b", :ptr? => false, :const? => false, :const_ptr? => false}
+                        ],
+                 :args_string=>"int a, unsigned int b",
+                 :args_call=>"a, b" }
+    assert_equal(expected, @parser.parse_declaration(source, ["ns1", "ns2"], "Bar"))
   end
 
   it "fully parse multiple prototypes" do
@@ -841,6 +891,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                               :void?  => false
                             },
                   :name=>"TheMatrix",
+                  :orig_name=>"TheMatrix",
+                  :namespace=>[],
+                  :class=>nil,
                   :modifier=>"const",
                   :contains_ptr? => true,
                   :args=>[ {:type=>"int",           :name=>"Trinity", :ptr? => false, :const? => false, :const_ptr? => false},
@@ -858,6 +911,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                               :void?  => false
                             },
                   :name=>"Morpheus",
+                  :orig_name=>"Morpheus",
+                  :namespace=>[],
+                  :class=>nil,
                   :modifier=>"",
                   :contains_ptr? => true,
                   :args=>[ {:type=>"int",           :name=>"cmock_arg1", :ptr? => false, :const? => false, :const_ptr? => false},
@@ -876,6 +932,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
 
     expected = [{ :var_arg=>nil,
                   :name=>"TheMatrix",
+                  :orig_name=>"TheMatrix",
+                  :namespace=>[],
+                  :class=>nil,
                   :return=> { :type   => "int",
                               :name   => 'cmock_to_return',
                               :ptr?   => false,
@@ -904,6 +963,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
 
     expected = [{ :var_arg => nil,
                   :name    => "PorkRoast",
+                  :orig_name => "PorkRoast",
+                  :namespace=>[],
+                  :class=>nil,
                   :return  => { :type       => "const int*",
                                 :name       => 'cmock_to_return',
                                 :ptr?       => true,
@@ -933,6 +995,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
 
     expected = [{ :var_arg => nil,
                   :name    => "PorkRoast",
+                  :orig_name => "PorkRoast",
+                  :namespace=>[],
+                  :class=>nil,
                   :return  => { :type       => "int const*",
                                 :name       => 'cmock_to_return',
                                 :ptr?       => true,
@@ -959,6 +1024,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
 
     expected = [{ :var_arg=>nil,
                   :name=>"PorkRoast",
+                  :orig_name=>"PorkRoast",
+                  :namespace=>[],
+                  :class=>nil,
                   :return=> { :type   => "int*",
                               :name   => 'cmock_to_return',
                               :ptr?   => true,
@@ -981,6 +1049,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
     source = "void foo(int const*, int*const, const int*, const int*const, int const*const, int*, int, const int);\n"
 
     expected = [{ :name => "foo",
+                  :orig_name => "foo",
+                  :namespace=>[],
+                  :class=>nil,
                   :modifier => "",
                   :return => { :type       => "void",
                                :name       => "cmock_to_return",
@@ -1013,6 +1084,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
              "         int const*const param5, int*param6, int param7, const int param8);\n"
 
     expected = [{ :name => "bar",
+                  :orig_name => "bar",
+                  :namespace=>[],
+                  :class=>nil,
                   :modifier => "",
                   :return => { :type       => "void",
                                :name       => "cmock_to_return",
@@ -1044,6 +1118,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
     source = "Book AddToBook(Book book, const IntArray values);\n"
 
     expected = [{ :name => "AddToBook",
+                  :orig_name => "AddToBook",
+                  :namespace=>[],
+                  :class=>nil,
                   :modifier=>"",
                   :return  => { :type       => "Book",
                                 :name       => "cmock_to_return",
@@ -1074,6 +1151,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
 
     expected = [{ :var_arg=>nil,
                   :name=>"DrHorrible",
+                  :orig_name=>"DrHorrible",
+                  :namespace=>[],
+                  :class=>nil,
                   :return  => { :type   => "void",
                                 :name   => 'cmock_to_return',
                                 :ptr?   => false,
@@ -1098,6 +1178,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                               :void?  => false
                             },
                   :name=>"CaptainHammer",
+                  :orig_name=>"CaptainHammer",
+                  :namespace=>[],
+                  :class=>nil,
                   :modifier=>"",
                   :contains_ptr? => false,
                   :args=>[ ],
@@ -1123,6 +1206,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                               :void?  => false
                             },
                   :name=>"DrHorrible",
+                  :orig_name=>"DrHorrible",
+                  :namespace=>[],
+                  :class=>nil,
                   :modifier=>"",
                   :contains_ptr? => false,
                   :args=>[ {:type=>"struct SingAlong", :name=>"Blog", :ptr? => false, :const? => false, :const_ptr? => false} ],
@@ -1139,6 +1225,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                               :void?  => true
                             },
                   :name=>"Penny",
+                  :orig_name=>"Penny",
+                  :namespace=>[],
+                  :class=>nil,
                   :modifier=>"",
                   :contains_ptr? => true,
                   :args=>[ {:type=>"struct const _KeepYourHeadUp_*", :name=>"BillyBuddy", :ptr? => true, :const? => true, :const_ptr? => true} ],
@@ -1155,6 +1244,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                               :void?  => false
                             },
                   :name=>"CaptainHammer",
+                  :orig_name=>"CaptainHammer",
+                  :namespace=>[],
+                  :class=>nil,
                   :modifier=>"",
                   :contains_ptr? => false,
                   :args=>[ ],
@@ -1176,6 +1268,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                             :void?  => true
                           },
                  :name=>"OrangePeel",
+                 :orig_name=>"OrangePeel",
+                 :namespace=>[],
+                 :class=>nil,
                  :modifier=>"",
                  :contains_ptr? => true,
                  :args=>[ {:type=>"union STARS_AND_STRIPES*", :name=>"a", :ptr? => true, :const? => false, :const_ptr? => false},
@@ -1199,6 +1294,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                             :void?  => true
                           },
                  :name=>"ApplePeel",
+                 :orig_name=>"ApplePeel",
+                 :namespace=>[],
+                 :class=>nil,
                  :modifier=>"",
                  :contains_ptr? => true,
                  :args=>[ {:type=> "unsigned int", :name=>"const_param", :ptr? => false, :const? => true, :const_ptr? => false},
@@ -1225,6 +1323,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                             :void?  => true
                           },
                  :name=>"LemonPeel",
+                 :orig_name=>"LemonPeel",
+                 :namespace=>[],
+                 :class=>nil,
                  :modifier=>"",
                  :contains_ptr? => true,
                  :args=>[ {:type=>"integer", :name=>"param", :ptr? => false, :const? => false, :const_ptr? => false},
@@ -1251,6 +1352,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                             :void?  => true
                           },
                  :name=>"CoinOperated",
+                 :orig_name=>"CoinOperated",
+                 :namespace=>[],
+                 :class=>nil,
                  :modifier=>"",
                  :contains_ptr? => false,
                  :args=>[ {:type=>"signed char", :name=>"abc", :ptr? => false, :const? => false, :const_ptr? => false},
@@ -1276,6 +1380,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                             :void?  => true
                           },
                  :name=>"CardOperated",
+                 :orig_name=>"CardOperated",
+                 :namespace=>[],
+                 :class=>nil,
                  :modifier=>"",
                  :contains_ptr? => true,
                  :args=>[ {:type=>"CUSTOM_TYPE", :name=>"abc", :ptr? => false, :const? => false, :const_ptr? => false},
@@ -1311,6 +1418,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                             :void?  => true
                           },
                  :name=>"KeyOperated",
+                 :orig_name=>"KeyOperated",
+                 :namespace=>[],
+                 :class=>nil,
                  :modifier=>"",
                  :contains_ptr? => true,
                  :args => expected_args,
@@ -1333,6 +1443,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                             :void?  => true
                           },
                  :name=>"Cheese",
+                 :orig_name=>"Cheese",
+                 :namespace=>[],
+                 :class=>nil,
                  :modifier=>"",
                  :contains_ptr? => false,
                  :args=>[ {:type=>"unsigned CUSTOM_TYPE", :name=>"abc", :ptr? => false, :const? => false, :const_ptr? => false},
@@ -1357,6 +1470,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                             :void?  => true
                           },
                  :name=>"FunkyTurkey",
+                 :orig_name=>"FunkyTurkey",
+                 :namespace=>[],
+                 :class=>nil,
                  :modifier=>"",
                  :contains_ptr? => false,
                  :args=>[ {:type=>"cmock_module_func_ptr1", :name=>"func_ptr", :ptr? => false, :const? => false, :const_ptr? => false}
@@ -1381,6 +1497,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                             :void?  => true
                           },
                  :name=>"FunkyTurkey",
+                 :orig_name=>"FunkyTurkey",
+                 :namespace=>[],
+                 :class=>nil,
                  :modifier=>"",
                  :contains_ptr? => false,
                  :args=>[ {:type=>"cmock_module_func_ptr1", :name=>"func_ptr", :ptr? => false, :const? => false, :const_ptr? => false}
@@ -1405,6 +1524,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                             :void?  => true
                           },
                  :name=>"FunkyTurkey",
+                 :orig_name=>"FunkyTurkey",
+                 :namespace=>[],
+                 :class=>nil,
                  :modifier=>"",
                  :contains_ptr? => false,
                  :args=>[ {:type=>"cmock_module_func_ptr1", :name=>"func_ptr", :ptr? => false, :const? => false, :const_ptr? => false}
@@ -1429,6 +1551,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                             :void?  => true
                           },
                  :name=>"FunkyTurkey",
+                 :orig_name=>"FunkyTurkey",
+                 :namespace=>[],
+                 :class=>nil,
                  :modifier=>"",
                  :contains_ptr? => false,
                  :args=>[ {:type=>"cmock_module_func_ptr1", :name=>"func_ptr", :ptr? => false, :const? => false, :const_ptr? => false}
@@ -1453,6 +1578,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                             :void?  => true
                           },
                  :name=>"FunkyChicken",
+                 :orig_name=>"FunkyChicken",
+                 :namespace=>[],
+                 :class=>nil,
                  :modifier=>"",
                  :contains_ptr? => false,
                  :args=>[ {:type=>"cmock_module_func_ptr1", :name=>"func_ptr", :ptr? => false, :const? => true, :const_ptr? => false}
@@ -1477,6 +1605,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                             # :void?  => true
                           # },
                  # :name=>"FunkyParrot",
+                 # :orig_name=>"FunkyParrot",
+                 # :namespace=>[],
+                 # :class=>nil,
                  # :modifier=>"",
                  # :contains_ptr? => false,
                  # :args=>[ {:type=>"cmock_module_func_ptr1", :name=>"func_ptr", :ptr? => false, :const? => false, :const_ptr? => false}
@@ -1501,6 +1632,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                             :void?  => true
                           },
                  :name=>"FunkyBudgie",
+                 :orig_name=>"FunkyBudgie",
+                 :namespace=>[],
+                 :class=>nil,
                  :modifier=>"",
                  :contains_ptr? => false,
                  :args=>[ {:type=>"cmock_module_func_ptr1", :name=>"func_ptr1", :ptr? => false, :const? => false, :const_ptr? => false},
@@ -1526,6 +1660,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                             :void?  => false
                           },
                  :name=>"FunkyRobin",
+                 :orig_name=>"FunkyRobin",
+                 :namespace=>[],
+                 :class=>nil,
                  :modifier=>"",
                  :contains_ptr? => false,
                  :args=>[ {:type=>"uint16_t", :name=>"num1", :ptr? => false, :const? => false, :const_ptr? => false},
@@ -1552,6 +1689,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                             :void?  => true
                           },
                  :name=>"FunkyFowl",
+                 :orig_name=>"FunkyFowl",
+                 :namespace=>[],
+                 :class=>nil,
                  :modifier=>"",
                  :contains_ptr? => false,
                  :args=>[ {:type=>"cmock_module_func_ptr1", :name=>"cmock_arg1", :ptr? => false, :const? => true, :const_ptr? => false}
@@ -1576,6 +1716,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                             :void?  => false
                           },
                  :name=>"FunkyPidgeon",
+                 :orig_name=>"FunkyPidgeon",
+                 :namespace=>[],
+                 :class=>nil,
                  :modifier=>"",
                  :contains_ptr? => false,
                  :args=>[ {:type=>"char", :name=>"op_code", :ptr? => false, :const? => true, :const_ptr? => false}
@@ -1600,6 +1743,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                             :void?  => false
                           },
                  :name=>"FunkyTweetie",
+                 :orig_name=>"FunkyTweetie",
+                 :namespace=>[],
+                 :class=>nil,
                  :modifier=>"",
                  :contains_ptr? => false,
                  :args=>[],
@@ -1623,6 +1769,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                             :void?  => false
                           },
                  :name=>"FunkySeaGull",
+                 :orig_name=>"FunkySeaGull",
+                 :namespace=>[],
+                 :class=>nil,
                  :modifier=>"",
                  :contains_ptr? => false,
                  :args=>[],
@@ -1646,6 +1795,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                             :void?  => false
                           },
                  :name=>"FunkyMacaw",
+                 :orig_name=>"FunkyMacaw",
+                 :namespace=>[],
+                 :class=>nil,
                  :modifier=>"",
                  :contains_ptr? => true,
                  :args=>[ {:type=>"double*", :name=>"foo", :ptr? => true, :const? => false, :const_ptr? => false},
@@ -1671,6 +1823,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                              :void?  => false
                            },
                    :name=>"sqlite3_bind_text",
+                   :orig_name=>"sqlite3_bind_text",
+                   :namespace=>[],
+                   :class=>nil,
                    :modifier=>"SQLITE_API",
                    :contains_ptr? => true,
                    :args=>[ {:type=>"sqlite3_stmt*", :name=>"cmock_arg2", :ptr? => true, :const? => false, :const_ptr? => false},
@@ -1699,6 +1854,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                               :void?  => false
                             },
                   :name=>"XFiles",
+                  :orig_name=>"XFiles",
+                  :namespace=>[],
+                  :class=>nil,
                   :modifier=>"",
                   :contains_ptr? => false,
                   :args=>[ {:type=>"int", :name=>"Scully", :ptr? => false, :const? => false, :const_ptr? => false},
@@ -1722,6 +1880,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                               :void?  => false
                             },
                   :name=>"MoreSillySongs",
+                  :orig_name=>"MoreSillySongs",
+                  :namespace=>[],
+                  :class=>nil,
                   :modifier=>"",
                   :contains_ptr? => true,
                   :args=>[ {:type=>"void*", :name=>"stuff", :ptr? => true, :const? => false, :const_ptr? => false}
@@ -1744,6 +1905,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                               :void?  => false
                             },
                   :name=>"LaverneAndShirley",
+                  :orig_name=>"LaverneAndShirley",
+                  :namespace=>[],
+                  :class=>nil,
                   :modifier=>"",
                   :contains_ptr? => false,
                   :args=>[ {:type=>"int", :name=>"Lenny", :ptr? => false, :const? => false, :const_ptr? => false},
@@ -1767,6 +1931,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                               :void?  => false
                             },
                   :name=>"TheCosbyShow",
+                  :orig_name=>"TheCosbyShow",
+                  :namespace=>[],
+                  :class=>nil,
                   :modifier=>"",
                   :contains_ptr? => false,
                   :args=>[ {:type=>"int", :name=>"Cliff", :ptr? => false, :const? => false, :const_ptr? => false},
@@ -2072,6 +2239,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                               :void?  => false
                             },
                   :name=>"LaverneAndShirley",
+                  :orig_name=>"LaverneAndShirley",
+                  :namespace=>[],
+                  :class=>nil,
                   :modifier=>"",
                   :contains_ptr? => false,
                   :args=>[ {:type=>"int", :name=>"Lenny", :ptr? => false, :const? => false, :const_ptr? => false},
@@ -2080,6 +2250,424 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                   :args_string=>"int Lenny, int Squiggy",
                   :args_call=>"Lenny, Squiggy"
                }]
+    assert_equal(expected, @parser.parse("module", source)[:functions])
+  end
+
+  it "imports C++ differently when asked" do
+    source =
+    [
+      "namespace ns1 {\n",
+      "  namespace ns2 {\n",
+      "\n",
+      "    class cls1 {\n",
+      "      public:\n",
+      "        int f_header_impl(int a, int b){\n",
+      "          return a + b;\n",
+      "        }\n",
+      "\n",
+      "        static void f_void();\n",
+      "        static int f_ret_simple();\n",
+      "        static int& f_ret_ref();\n",
+      "\n",
+      "      protected:\n",
+      "        static void protected_f_void();\n",
+      "\n",
+      "      public:\n",
+      "      private:\n",
+      "        static void private_f_void();\n",
+      "    }; // cls1\n",
+      "  } // ns2\n",
+      "} // ns1\n"
+    ].join
+
+    expected =
+    [
+      "namespace ns1 { namespace ns2 { class cls1 { public: int f_header_impl",
+      "static void f_void()",
+      "static int f_ret_simple()",
+      "static int& f_ret_ref()",
+      "protected: static void protected_f_void()",
+      "public: private: static void private_f_void()",
+      "}",
+      "} }"
+    ]
+
+    assert_equal(expected, @parser.import_source(source, cpp=true))
+    refute_equal(expected, @parser.import_source(source))
+  end
+
+  # only so parse_functions does not raise an error
+  def dummy_source
+    "void dummy(void);"
+  end
+
+  # Expected result of above
+  def dummy_func
+    { :name => "dummy",
+      :orig_name => "dummy",
+      :class => nil,
+      :namespace => [],
+      :var_arg => nil,
+      :args_string => "void",
+      :args => [],
+      :args_call => "",
+      :contains_ptr? => false,
+      :modifier => "",
+      :return => {
+        :type => "void",
+        :name => "cmock_to_return",
+        :str => "void cmock_to_return",
+        :void? => true,
+        :ptr? => false,
+        :const? => false,
+        :const_ptr? => false}}
+  end
+
+  # Commonly used example function
+  def voidvoid_func(namespace=[], name="Classic_functional")
+    { :name => name,
+      :orig_name => "functional",
+      :class => "Classic",
+      :namespace => namespace,
+      :var_arg => nil,
+      :args_string => "void",
+      :args => [],
+      :args_call => "",
+      :contains_ptr? => false,
+      :modifier => "",
+      :return => {
+        :type=>"void",
+        :name=>"cmock_to_return",
+        :str=>"void cmock_to_return",
+        :void? => true,
+        :ptr? => false,
+        :const? => false,
+        :const_ptr? => false}}
+  end
+
+  it "parses public C++ functions" do
+    source = dummy_source + <<~SOURCE
+      class Classic {
+        public:
+          static void functional(void);
+      };
+    SOURCE
+
+    expected = [dummy_func, voidvoid_func]
+
+    assert_equal(expected, @parser.parse("module", source)[:functions])
+  end
+
+  it "handles a namespace" do
+    source = dummy_source + <<~SOURCE
+      namespace ns1 {
+        class Classic {
+          public:
+            static void functional(void);
+        };
+      } // ns1
+    SOURCE
+
+    expected = [dummy_func,
+      voidvoid_func(namespace=["ns1"], name="ns1_Classic_functional")]
+
+    assert_equal(expected, @parser.parse("module", source)[:functions])
+  end
+
+  it "handles nested namespaces" do
+    source = dummy_source + <<~SOURCE
+      namespace ns1 {
+        namespace ns2 {
+          class Classic {
+            public:
+              static void functional(void);
+          };
+        } // ns1
+      } // ns1
+    SOURCE
+
+    expected = [dummy_func,
+      voidvoid_func(namespace=["ns1", "ns2"], name="ns1_ns2_Classic_functional")]
+
+    assert_equal(expected, @parser.parse("module", source)[:functions])
+  end
+
+  it "ignores non-static C++ functions" do
+    source = dummy_source + <<~SOURCE
+      class Classic {
+        public:
+          void functional(void);
+      };
+    SOURCE
+
+    expected = [dummy_func]
+
+    assert_equal(expected, @parser.parse("module", source)[:functions])
+  end
+
+  it "ignores private functions" do
+    source = dummy_source + <<~SOURCE
+      class Classic {
+        private:
+          static void functional(void);
+      };
+    SOURCE
+
+    expected = [dummy_func]
+
+    assert_equal(expected, @parser.parse("module", source)[:functions])
+  end
+
+  it "parses public C++ functions after private functions" do
+    source = dummy_source + <<~SOURCE
+      class Classic {
+        private:
+          static void ignoreme(void);
+        public:
+          static void functional(void);
+      };
+    SOURCE
+
+    expected = [dummy_func, voidvoid_func]
+
+    assert_equal(expected, @parser.parse("module", source)[:functions])
+  end
+
+  it "ignores protected functions" do
+    source = dummy_source + <<~SOURCE
+      class Classic {
+        protected:
+          static void functional(void);
+      };
+    SOURCE
+
+    expected = [dummy_func]
+
+    assert_equal(expected, @parser.parse("module", source)[:functions])
+  end
+
+  it "parses public C++ functions after protected functions" do
+    source = dummy_source + <<~SOURCE
+      class Classic {
+        protected:
+          static void ignoreme(void);
+        public:
+          static void functional(void);
+      };
+    SOURCE
+
+    expected = [dummy_func, voidvoid_func]
+
+    assert_equal(expected, @parser.parse("module", source)[:functions])
+  end
+
+  it "parses functions with a reference return type" do
+    source = <<~SOURCE
+      int& dummy(void);
+
+      class Classic {
+        public:
+          static int& functional(void);
+      };
+    SOURCE
+
+    # Verify both classic C and C++ examples
+    expected = [
+      { :name => "dummy",
+        :orig_name => "dummy",
+        :class => nil,
+        :namespace => [],
+        :var_arg => nil,
+        :args_string => "void",
+        :args => [],
+        :args_call => "",
+        :contains_ptr? => false,
+        :modifier => "",
+        :return => {
+          :type=>"int&",
+          :name=>"cmock_to_return",
+          :str=>"int& cmock_to_return",
+          :void? => false,
+          :ptr? => false,
+          :const? => false,
+          :const_ptr? => false}},
+      { :name => "Classic_functional",
+        :orig_name => "functional",
+        :class => "Classic",
+        :namespace => [],
+        :var_arg => nil,
+        :args_string => "void",
+        :args => [],
+        :args_call => "",
+        :contains_ptr? => false,
+        :modifier => "",
+        :return => {
+          :type=>"int&",
+          :name=>"cmock_to_return",
+          :str=>"int& cmock_to_return",
+          :void? => false,
+          :ptr? => false,
+          :const? => false,
+          :const_ptr? => false}}]
+
+    assert_equal(expected, @parser.parse("module", source)[:functions])
+  end
+
+  # Known limitation - would be great to overcome in future
+  it "cannot handle reference type args" do
+    source = dummy_source + <<~SOURCE
+      class Classic {
+        public:
+          static void functional(int& a);
+      };
+    SOURCE
+
+    expected = [dummy_func]
+
+    assert_equal(expected, @parser.parse("module", source)[:functions])
+  end
+
+  it "parses multiple classes in same file with uniquely named functions" do
+    source = dummy_source + <<~SOURCE
+      namespace ns1 {
+        class Classic {
+          public:
+            static void functional(void);
+        };
+
+        class Classical {
+          public:
+            static int functionality(int a);
+        };
+      } // ns1
+
+      class Classy {
+        public:
+          static int* func(int* a);
+      };
+    SOURCE
+
+    expected = [dummy_func,
+      voidvoid_func(["ns1"], name="ns1_Classic_functional"),
+      { :name => "ns1_Classical_functionality",
+        :orig_name => "functionality",
+        :class => "Classical",
+        :namespace => ["ns1"],
+        :var_arg => nil,
+        :args_string => "int a",
+        :args => [
+          { :ptr? => false,
+            :const? => false,
+            :const_ptr? => false,
+            :name => "a",
+            :type => "int"}],
+        :args_call => "a",
+        :contains_ptr? => false,
+        :modifier => "",
+        :return => {
+          :type=>"int",
+          :name=>"cmock_to_return",
+          :str=>"int cmock_to_return",
+          :void? => false,
+          :ptr? => false,
+          :const? => false,
+          :const_ptr? => false}},
+      { :name => "Classy_func",
+        :orig_name => "func",
+        :class => "Classy",
+        :namespace => [],
+        :var_arg => nil,
+        :args_string => "int* a",
+        :args => [
+          { :ptr? => true,
+            :const? => false,
+            :const_ptr? => false,
+            :name => "a",
+            :type => "int*"}],
+        :args_call => "a",
+        :contains_ptr? => true,
+        :modifier => "",
+        :return => {
+          :type=>"int*",
+          :name=>"cmock_to_return",
+          :str=>"int* cmock_to_return",
+          :void? => false,
+          :ptr? => true,
+          :const? => false,
+          :const_ptr? => false}}]
+
+    assert_equal(expected, @parser.parse("module", source)[:functions])
+  end
+
+  it "handles multiple classes in same file with identically named functions" do
+    source = dummy_source + <<~SOURCE
+      namespace ns1 {
+        class Classic {
+          public:
+            static void functional(void);
+        };
+
+        class Classical {
+          public:
+            static int functional(int a);
+        };
+      } // ns1
+
+      class Classy {
+        public:
+          static int* functional(int* a);
+      };
+    SOURCE
+
+    expected = [dummy_func,
+      voidvoid_func(["ns1"], name="ns1_Classic_functional"),
+      { :name => "ns1_Classical_functional",
+        :orig_name => "functional",
+        :class => "Classical",
+        :namespace => ["ns1"],
+        :var_arg => nil,
+        :args_string => "int a",
+        :args => [
+          { :ptr? => false,
+            :const? => false,
+            :const_ptr? => false,
+            :name => "a",
+            :type => "int"}],
+        :args_call => "a",
+        :contains_ptr? => false,
+        :modifier => "",
+        :return => {
+          :type=>"int",
+          :name=>"cmock_to_return",
+          :str=>"int cmock_to_return",
+          :void? => false,
+          :ptr? => false,
+          :const? => false,
+          :const_ptr? => false}},
+      { :name => "Classy_functional",
+        :orig_name => "functional",
+        :class => "Classy",
+        :namespace => [],
+        :var_arg => nil,
+        :args_string => "int* a",
+        :args => [
+          { :ptr? => true,
+            :const? => false,
+            :const_ptr? => false,
+            :name => "a",
+            :type => "int*"}],
+        :args_call => "a",
+        :contains_ptr? => true,
+        :modifier => "",
+        :return => {
+          :type=>"int*",
+          :name=>"cmock_to_return",
+          :str=>"int* cmock_to_return",
+          :void? => false,
+          :ptr? => true,
+          :const? => false,
+          :const_ptr? => false}}]
+
     assert_equal(expected, @parser.parse("module", source)[:functions])
   end
 


### PR DESCRIPTION
This is an updated version of https://github.com/ThrowTheSwitch/CMock/pull/284 (the repository for that is currently archived so I cannot update the original PR)