### PR TITLE
change CMOCK_MEM_INDEX_TYPE default type to size_t

### DIFF
--- a/docs/CMock_Summary.md
+++ b/docs/CMock_Summary.md
@@ -732,7 +732,7 @@ based on other settings, particularly Unity's settings.
 
 * `CMOCK_MEM_INDEX_TYPE`
   This needs to be something big enough to point anywhere in Cmock's
-  memory space... usually it's an unsigned int.
+  memory space... usually it's a size_t.
 
 Other Tips
 ==========

--- a/src/cmock.h
+++ b/src/cmock.h
@@ -16,7 +16,8 @@
 
 /* should be big enough to index full range of CMOCK_MEM_MAX */
 #ifndef CMOCK_MEM_INDEX_TYPE
-#define CMOCK_MEM_INDEX_TYPE  unsigned int
+#include <stddef.h>
+#define CMOCK_MEM_INDEX_TYPE  size_t
 #endif
 
 #define CMOCK_GUTS_NONE   (0)


### PR DESCRIPTION
This should improve compatibility with 64-bit and may address https://github.com/ThrowTheSwitch/CMock/issues/165