### PR TITLE
convert Boolean values from int to char to reduce memory

### DIFF
--- a/lib/cmock_generator_plugin_callback.rb
+++ b/lib/cmock_generator_plugin_callback.rb
@@ -19,7 +19,7 @@ class CMockGeneratorPluginCallback
 
   def instance_structure(function)
     func_name = function[:name]
-    "  int #{func_name}_CallbackBool;\n" \
+    "  char #{func_name}_CallbackBool;\n" \
     "  CMOCK_#{func_name}_CALLBACK #{func_name}_CallbackFunctionPointer;\n" \
     "  int #{func_name}_CallbackCalls;\n"
   end
@@ -70,12 +70,12 @@ class CMockGeneratorPluginCallback
     has_ignore = @config.plugins.include? :ignore
     lines = ''
     lines << "void #{func_name}_AddCallback(CMOCK_#{func_name}_CALLBACK Callback)\n{\n"
-    lines << "  Mock.#{func_name}_IgnoreBool = (int)0;\n" if has_ignore
-    lines << "  Mock.#{func_name}_CallbackBool = (int)1;\n"
+    lines << "  Mock.#{func_name}_IgnoreBool = (char)0;\n" if has_ignore
+    lines << "  Mock.#{func_name}_CallbackBool = (char)1;\n"
     lines << "  Mock.#{func_name}_CallbackFunctionPointer = Callback;\n}\n\n"
     lines << "void #{func_name}_Stub(CMOCK_#{func_name}_CALLBACK Callback)\n{\n"
-    lines << "  Mock.#{func_name}_IgnoreBool = (int)0;\n" if has_ignore
-    lines << "  Mock.#{func_name}_CallbackBool = (int)0;\n"
+    lines << "  Mock.#{func_name}_IgnoreBool = (char)0;\n" if has_ignore
+    lines << "  Mock.#{func_name}_CallbackBool = (char)0;\n"
     lines << "  Mock.#{func_name}_CallbackFunctionPointer = Callback;\n}\n\n"
   end
 

--- a/lib/cmock_generator_plugin_expect_any_args.rb
+++ b/lib/cmock_generator_plugin_expect_any_args.rb
@@ -15,7 +15,7 @@ class CMockGeneratorPluginExpectAnyArgs
   end
 
   def instance_typedefs(_function)
-    "  int ExpectAnyArgsBool;\n"
+    "  char ExpectAnyArgsBool;\n"
   end
 
   def mock_function_declarations(function)
@@ -42,7 +42,7 @@ class CMockGeneratorPluginExpectAnyArgs
       unless function[:return][:void?]
         lines << "  cmock_call_instance->ReturnVal = cmock_to_return;\n"
       end
-      lines << "  cmock_call_instance->ExpectAnyArgsBool = (int)1;\n"
+      lines << "  cmock_call_instance->ExpectAnyArgsBool = (char)1;\n"
       lines << "}\n\n"
     end
     lines

--- a/lib/cmock_generator_plugin_ignore.rb
+++ b/lib/cmock_generator_plugin_ignore.rb
@@ -16,9 +16,9 @@ class CMockGeneratorPluginIgnore
 
   def instance_structure(function)
     if function[:return][:void?]
-      "  int #{function[:name]}_IgnoreBool;\n"
+      "  char #{function[:name]}_IgnoreBool;\n"
     else
-      "  int #{function[:name]}_IgnoreBool;\n  #{function[:return][:type]} #{function[:name]}_FinalReturn;\n"
+      "  char #{function[:name]}_IgnoreBool;\n  #{function[:return][:type]} #{function[:name]}_FinalReturn;\n"
     end
   end
 
@@ -59,12 +59,12 @@ class CMockGeneratorPluginIgnore
     unless function[:return][:void?]
       lines << "  cmock_call_instance->ReturnVal = cmock_to_return;\n"
     end
-    lines << "  Mock.#{function[:name]}_IgnoreBool = (int)1;\n"
+    lines << "  Mock.#{function[:name]}_IgnoreBool = (char)1;\n"
     lines << "}\n\n"
   end
 
   def mock_ignore(function)
-    "  Mock.#{function[:name]}_IgnoreBool = (int) 1;\n"
+    "  Mock.#{function[:name]}_IgnoreBool = (char) 1;\n"
   end
 
   def mock_verify(function)

--- a/lib/cmock_generator_plugin_ignore_arg.rb
+++ b/lib/cmock_generator_plugin_ignore_arg.rb
@@ -10,7 +10,7 @@ class CMockGeneratorPluginIgnoreArg
   def instance_typedefs(function)
     lines = ''
     function[:args].each do |arg|
-      lines << "  int IgnoreArg_#{arg[:name]};\n"
+      lines << "  char IgnoreArg_#{arg[:name]};\n"
     end
     lines
   end

--- a/lib/cmock_generator_plugin_return_thru_ptr.rb
+++ b/lib/cmock_generator_plugin_return_thru_ptr.rb
@@ -12,7 +12,7 @@ class CMockGeneratorPluginReturnThruPtr
     function[:args].each do |arg|
       next unless @utils.ptr_or_str?(arg[:type]) && !(arg[:const?])
 
-      lines << "  int ReturnThruPtr_#{arg[:name]}_Used;\n"
+      lines << "  char ReturnThruPtr_#{arg[:name]}_Used;\n"
       lines << "  #{arg[:type]} ReturnThruPtr_#{arg[:name]}_Val;\n"
       lines << "  int ReturnThruPtr_#{arg[:name]}_Size;\n"
     end

--- a/lib/cmock_generator_utils.rb
+++ b/lib/cmock_generator_utils.rb
@@ -52,11 +52,11 @@ class CMockGeneratorUtils
     lines << "  UNITY_TEST_ASSERT_NOT_NULL(cmock_call_instance, cmock_line, CMockStringOutOfMemory);\n"
     lines << "  memset(cmock_call_instance, 0, sizeof(*cmock_call_instance));\n"
     lines << "  Mock.#{func_name}_CallInstance = CMock_Guts_MemChain(Mock.#{func_name}_CallInstance, cmock_guts_index);\n"
-    lines << "  Mock.#{func_name}_IgnoreBool = (int)0;\n" if @ignore
+    lines << "  Mock.#{func_name}_IgnoreBool = (char)0;\n" if @ignore
     lines << "  cmock_call_instance->LineNumber = cmock_line;\n"
     lines << "  cmock_call_instance->CallOrder = ++GlobalExpectCount;\n" if @ordered && global_ordering_supported
     lines << "  cmock_call_instance->ExceptionToThrow = CEXCEPTION_NONE;\n" if @cexception
-    lines << "  cmock_call_instance->ExpectAnyArgsBool = (int)0;\n" if @expect_any
+    lines << "  cmock_call_instance->ExpectAnyArgsBool = (char)0;\n" if @expect_any
     lines
   end
 

--- a/test/unit/cmock_generator_plugin_callback_test.rb
+++ b/test/unit/cmock_generator_plugin_callback_test.rb
@@ -32,7 +32,7 @@ describe CMockGeneratorPluginCallback, "Verify CMockGeneratorPluginCallback Modu
 
   it "add to instance structure" do
     function = {:name => "Oak", :args => [:type => "int*", :name => "blah", :ptr? => true], :return => test_return[:int_ptr]}
-    expected = "  int Oak_CallbackBool;\n" +
+    expected = "  char Oak_CallbackBool;\n" +
                "  CMOCK_Oak_CALLBACK Oak_CallbackFunctionPointer;\n" +
                "  int Oak_CallbackCalls;\n"
     returned = @cmock_generator_plugin_callback.instance_structure(function)
@@ -264,14 +264,14 @@ describe CMockGeneratorPluginCallback, "Verify CMockGeneratorPluginCallback Modu
 
     expected = ["void Lemon_AddCallback(CMOCK_Lemon_CALLBACK Callback)\n",
                 "{\n",
-                "  Mock.Lemon_IgnoreBool = (int)0;\n",
-                "  Mock.Lemon_CallbackBool = (int)1;\n",
+                "  Mock.Lemon_IgnoreBool = (char)0;\n",
+                "  Mock.Lemon_CallbackBool = (char)1;\n",
                 "  Mock.Lemon_CallbackFunctionPointer = Callback;\n",
                 "}\n\n",
                 "void Lemon_Stub(CMOCK_Lemon_CALLBACK Callback)\n",
                 "{\n",
-                "  Mock.Lemon_IgnoreBool = (int)0;\n",
-                "  Mock.Lemon_CallbackBool = (int)0;\n",
+                "  Mock.Lemon_IgnoreBool = (char)0;\n",
+                "  Mock.Lemon_CallbackBool = (char)0;\n",
                 "  Mock.Lemon_CallbackFunctionPointer = Callback;\n",
                 "}\n\n"
                ].join

--- a/test/unit/cmock_generator_plugin_expect_any_args_test.rb
+++ b/test/unit/cmock_generator_plugin_expect_any_args_test.rb
@@ -57,7 +57,7 @@ describe CMockGeneratorPluginExpectAnyArgs, "Verify CMockGeneratorPluginExpectAn
     expected = ["void Slime_CMockExpectAnyArgs(UNITY_LINE_TYPE cmock_line)\n",
                 "{\n",
                 "mock_return_1",
-                "  cmock_call_instance->ExpectAnyArgsBool = (int)1;\n",
+                "  cmock_call_instance->ExpectAnyArgsBool = (char)1;\n",
                 "}\n\n"
                ].join
     @utils.expect :code_add_base_expectation, "mock_return_1", ["Slime", true]

--- a/test/unit/cmock_generator_plugin_ignore_arg_test.rb
+++ b/test/unit/cmock_generator_plugin_ignore_arg_test.rb
@@ -54,9 +54,9 @@ describe CMockGeneratorPluginIgnoreArg, "Verify CMockGeneratorPluginIgnoreArg Mo
   end
 
   it "add to tyepdef structure mock needs of functions of style 'void func(int chicken, int* pork)'" do
-    expected = "  int IgnoreArg_chicken;\n" +
-               "  int IgnoreArg_beef;\n" +
-               "  int IgnoreArg_tofu;\n"
+    expected = "  char IgnoreArg_chicken;\n" +
+               "  char IgnoreArg_beef;\n" +
+               "  char IgnoreArg_tofu;\n"
     returned = @cmock_generator_plugin_ignore_arg.instance_typedefs(@complex_func)
     assert_equal(expected, returned)
   end

--- a/test/unit/cmock_generator_plugin_ignore_test.rb
+++ b/test/unit/cmock_generator_plugin_ignore_test.rb
@@ -28,7 +28,7 @@ describe CMockGeneratorPluginIgnore, "Verify CMockGeneratorPluginIgnore Module" 
 
   it "add a required variable to the instance structure" do
     function = {:name => "Grass", :args => [], :return => test_return[:void]}
-    expected = "  int Grass_IgnoreBool;\n"
+    expected = "  char Grass_IgnoreBool;\n"
     returned = @cmock_generator_plugin_ignore.instance_structure(function)
     assert_equal(expected, returned)
   end
@@ -81,7 +81,7 @@ describe CMockGeneratorPluginIgnore, "Verify CMockGeneratorPluginIgnore Module" 
     function = {:name => "Slime", :args => [], :args_string => "void", :return => test_return[:void]}
     expected = ["void Slime_CMockIgnore(void)\n",
                 "{\n",
-                "  Mock.Slime_IgnoreBool = (int)1;\n",
+                "  Mock.Slime_IgnoreBool = (char)1;\n",
                 "}\n\n"
                ].join
     returned = @cmock_generator_plugin_ignore.mock_interfaces(function)
@@ -95,7 +95,7 @@ describe CMockGeneratorPluginIgnore, "Verify CMockGeneratorPluginIgnore Module" 
                 "{\n",
                 "mock_return_1",
                 "  cmock_call_instance->ReturnVal = cmock_to_return;\n",
-                "  Mock.Slime_IgnoreBool = (int)1;\n",
+                "  Mock.Slime_IgnoreBool = (char)1;\n",
                 "}\n\n"
                ].join
     returned = @cmock_generator_plugin_ignore.mock_interfaces(function)

--- a/test/unit/cmock_generator_plugin_return_thru_ptr_test.rb
+++ b/test/unit/cmock_generator_plugin_return_thru_ptr_test.rb
@@ -71,7 +71,7 @@ describe CMockGeneratorPluginReturnThruPtr, "Verify CMockGeneratorPluginReturnTh
 
   it "add to tyepdef structure mock needs of functions of style 'void func(int chicken, int* pork)'" do
     complex_func_expect()
-    expected = "  int ReturnThruPtr_tofu_Used;\n" +
+    expected = "  char ReturnThruPtr_tofu_Used;\n" +
                "  int* ReturnThruPtr_tofu_Val;\n" +
                "  int ReturnThruPtr_tofu_Size;\n"
     returned = @cmock_generator_plugin_return_thru_ptr.instance_typedefs(@complex_func)

--- a/test/unit/cmock_generator_utils_test.rb
+++ b/test/unit/cmock_generator_utils_test.rb
@@ -73,7 +73,7 @@ describe CMockGeneratorUtils, "Verify CMockGeneratorUtils Module" do
       "  UNITY_TEST_ASSERT_NOT_NULL(cmock_call_instance, cmock_line, CMockStringOutOfMemory);\n" +
       "  memset(cmock_call_instance, 0, sizeof(*cmock_call_instance));\n" +
       "  Mock.Apple_CallInstance = CMock_Guts_MemChain(Mock.Apple_CallInstance, cmock_guts_index);\n" +
-      "  Mock.Apple_IgnoreBool = (int)0;\n" +
+      "  Mock.Apple_IgnoreBool = (char)0;\n" +
       "  cmock_call_instance->LineNumber = cmock_line;\n" +
       "  cmock_call_instance->CallOrder = ++GlobalExpectCount;\n" +
       "  cmock_call_instance->ExceptionToThrow = CEXCEPTION_NONE;\n"
@@ -88,7 +88,7 @@ describe CMockGeneratorUtils, "Verify CMockGeneratorUtils Module" do
       "  UNITY_TEST_ASSERT_NOT_NULL(cmock_call_instance, cmock_line, CMockStringOutOfMemory);\n" +
       "  memset(cmock_call_instance, 0, sizeof(*cmock_call_instance));\n" +
       "  Mock.Apple_CallInstance = CMock_Guts_MemChain(Mock.Apple_CallInstance, cmock_guts_index);\n" +
-      "  Mock.Apple_IgnoreBool = (int)0;\n" +
+      "  Mock.Apple_IgnoreBool = (char)0;\n" +
       "  cmock_call_instance->LineNumber = cmock_line;\n" +
       "  cmock_call_instance->ExceptionToThrow = CEXCEPTION_NONE;\n"
     output = @cmock_generator_utils_complex.code_add_base_expectation("Apple", false)


### PR DESCRIPTION
If we really want to optimize more then we could try using bit-fields, but I'm wary that some platforms or older compilers might have issues with that even though it's part of C89