### PR TITLE
add <function>_StopIgnore()  function

### DIFF
--- a/docs/CMock_Summary.md
+++ b/docs/CMock_Summary.md
@@ -166,7 +166,7 @@ StopIgnore:
 
 Maybe you want to ignore a particular function for part of a test but dont want to 
 ignore it later on. In that case, you want to use StopIgnore which will cancel the 
-previously called Ignore or IgnoreAndReturn requireing you to Expect or otherwise
+previously called Ignore or IgnoreAndReturn requiring you to Expect or otherwise
 handle the call to a function. 
 
 * `void func(void)` => `void func_StopIgnore(void)`

--- a/docs/CMock_Summary.md
+++ b/docs/CMock_Summary.md
@@ -164,10 +164,10 @@ care how many times it was called, right?
 StopIgnore:
 -------
 
-Maybe you want to ignore a particular function for part of a test but dont want to 
-ignore it later on. In that case, you want to use StopIgnore which will cancel the 
+Maybe you want to ignore a particular function for part of a test but dont want to
+ignore it later on. In that case, you want to use StopIgnore which will cancel the
 previously called Ignore or IgnoreAndReturn requiring you to Expect or otherwise
-handle the call to a function. 
+handle the call to a function.
 
 * `void func(void)` => `void func_StopIgnore(void)`
 * `void func(params)` => `void func_StopIgnore(void)`

--- a/docs/CMock_Summary.md
+++ b/docs/CMock_Summary.md
@@ -161,6 +161,18 @@ care how many times it was called, right?
 * `retval func(void)` => `void func_IgnoreAndReturn(retval_to_return)`
 * `retval func(params)` => `void func_IgnoreAndReturn(retval_to_return)`
 
+StopIgnore:
+-------
+
+Maybe you want to ignore a particular function for part of a test but dont want to 
+ignore it later on. In that case, you want to use StopIgnore which will cancel the 
+previously called Ignore or IgnoreAndReturn requireing you to Expect or otherwise
+handle the call to a function. 
+
+* `void func(void)` => `void func_StopIgnore(void)`
+* `void func(params)` => `void func_StopIgnore(void)`
+* `retval func(void)` => `void func_StopIgnore(void)`
+* `retval func(params)` => `void func_StopIgnore(void)`
 
 Ignore Arg:
 ------------

--- a/lib/cmock_generator_plugin_ignore.rb
+++ b/lib/cmock_generator_plugin_ignore.rb
@@ -24,15 +24,17 @@ class CMockGeneratorPluginIgnore
 
   def mock_function_declarations(function)
     if function[:return][:void?]
-      "#define #{function[:name]}_Ignore() #{function[:name]}_CMockIgnore()\n" \
+    lines =   "#define #{function[:name]}_Ignore() #{function[:name]}_CMockIgnore()\n" \
              "void #{function[:name]}_CMockIgnore(void);\n"
     else
-      "#define #{function[:name]}_IgnoreAndReturn(cmock_retval) #{function[:name]}_CMockIgnoreAndReturn(__LINE__, cmock_retval)\n" \
+     lines =  "#define #{function[:name]}_IgnoreAndReturn(cmock_retval) #{function[:name]}_CMockIgnoreAndReturn(__LINE__, cmock_retval)\n" \
              "void #{function[:name]}_CMockIgnoreAndReturn(UNITY_LINE_TYPE cmock_line, #{function[:return][:str]});\n"
     end
+    
     #add stop ignore function. it does not matter if there are any args
-    "#define #{function[:name]}_StopIgnore() #{function[:name]}_CMockStopIgnore()\n" \
-         "void #{function[:name]}_CMockStopIgnore(void);\n"
+    lines << "#define #{function[:name]}_StopIgnore() #{function[:name]}_CMockStopIgnore()\n" \
+                "void #{function[:name]}_CMockStopIgnore(void);\n"
+    lines
   end
 
   def mock_implementation_precheck(function)
@@ -67,7 +69,12 @@ class CMockGeneratorPluginIgnore
   
     #add stop ignore function. it does not matter if there are any args
     lines << "void #{function[:name]}_CMockStopIgnore(void)\n{\n"
-    lines << "  Mock.#{function[:name]}_IgnoreBool = (char)0;\n"
+    lines << "  if(Mock.#{function[:name]}_IgnoreBool) {\n"
+    lines << "    Mock.#{function[:name]}_IgnoreBool = (char)0;\n"
+    unless function[:return][:void?]
+      lines << "    Mock.#{function[:name]}_CallInstance = CMock_Guts_MemNext(Mock.#{function[:name]}_CallInstance);\n"
+    end
+    lines << "  }\n"
     lines << "}\n\n"
   end
 

--- a/lib/cmock_generator_plugin_ignore.rb
+++ b/lib/cmock_generator_plugin_ignore.rb
@@ -24,10 +24,10 @@ class CMockGeneratorPluginIgnore
 
   def mock_function_declarations(function)
     if function[:return][:void?]
-    lines =   "#define #{function[:name]}_Ignore() #{function[:name]}_CMockIgnore()\n" \
+      lines =   "#define #{function[:name]}_Ignore() #{function[:name]}_CMockIgnore()\n" \
              "void #{function[:name]}_CMockIgnore(void);\n"
     else
-     lines =  "#define #{function[:name]}_IgnoreAndReturn(cmock_retval) #{function[:name]}_CMockIgnoreAndReturn(__LINE__, cmock_retval)\n" \
+      lines =  "#define #{function[:name]}_IgnoreAndReturn(cmock_retval) #{function[:name]}_CMockIgnoreAndReturn(__LINE__, cmock_retval)\n" \
              "void #{function[:name]}_CMockIgnoreAndReturn(UNITY_LINE_TYPE cmock_line, #{function[:return][:str]});\n"
     end
     
@@ -68,13 +68,12 @@ class CMockGeneratorPluginIgnore
     lines << "}\n\n"
   
     #add stop ignore function. it does not matter if there are any args
-    lines << "void #{function[:name]}_CMockStopIgnore(void)\n{\n"
-    lines << "  if(Mock.#{function[:name]}_IgnoreBool) {\n"
-    lines << "    Mock.#{function[:name]}_IgnoreBool = (char)0;\n"
+    lines << "void #{function[:name]}_CMockStopIgnore(void)\n  {\n"
     unless function[:return][:void?]
+      lines << "  if(Mock.#{function[:name]}_IgnoreBool) \n"
       lines << "    Mock.#{function[:name]}_CallInstance = CMock_Guts_MemNext(Mock.#{function[:name]}_CallInstance);\n"
     end
-    lines << "  }\n"
+    lines << "  Mock.#{function[:name]}_IgnoreBool = (char)0;\n"
     lines << "}\n\n"
   end
 

--- a/lib/cmock_generator_plugin_ignore.rb
+++ b/lib/cmock_generator_plugin_ignore.rb
@@ -30,10 +30,10 @@ class CMockGeneratorPluginIgnore
       lines =  "#define #{function[:name]}_IgnoreAndReturn(cmock_retval) #{function[:name]}_CMockIgnoreAndReturn(__LINE__, cmock_retval)\n" \
              "void #{function[:name]}_CMockIgnoreAndReturn(UNITY_LINE_TYPE cmock_line, #{function[:return][:str]});\n"
     end
-    
+
     #add stop ignore function. it does not matter if there are any args
     lines << "#define #{function[:name]}_StopIgnore() #{function[:name]}_CMockStopIgnore()\n" \
-                "void #{function[:name]}_CMockStopIgnore(void);\n"
+                "void #{function[:name]}_CMockStopIgnore(void);\n"void #{function[:name]}_CMockIgnoreAndReturn(UNITY_LINE_TYPE cmock_line, #{function[:return][:str]});\n
     lines
   end
 
@@ -68,9 +68,9 @@ class CMockGeneratorPluginIgnore
     lines << "}\n\n"
   
     #add stop ignore function. it does not matter if there are any args
-    lines << "void #{function[:name]}_CMockStopIgnore(void)\n  {\n"
+    lines << "void #{function[:name]}_CMockStopIgnore(void)\n{\n"
     unless function[:return][:void?]
-      lines << "  if(Mock.#{function[:name]}_IgnoreBool) \n"
+      lines << "  if(Mock.#{function[:name]}_IgnoreBool)\n"
       lines << "    Mock.#{function[:name]}_CallInstance = CMock_Guts_MemNext(Mock.#{function[:name]}_CallInstance);\n"
     end
     lines << "  Mock.#{function[:name]}_IgnoreBool = (char)0;\n"

--- a/lib/cmock_generator_plugin_ignore.rb
+++ b/lib/cmock_generator_plugin_ignore.rb
@@ -30,6 +30,9 @@ class CMockGeneratorPluginIgnore
       "#define #{function[:name]}_IgnoreAndReturn(cmock_retval) #{function[:name]}_CMockIgnoreAndReturn(__LINE__, cmock_retval)\n" \
              "void #{function[:name]}_CMockIgnoreAndReturn(UNITY_LINE_TYPE cmock_line, #{function[:return][:str]});\n"
     end
+    #add stop ignore function. it does not matter if there are any args
+    "#define #{function[:name]}_StopIgnore() #{function[:name]}_CMockStopIgnore()\n" \
+         "void #{function[:name]}_CMockStopIgnore(void);\n"
   end
 
   def mock_implementation_precheck(function)
@@ -60,6 +63,11 @@ class CMockGeneratorPluginIgnore
       lines << "  cmock_call_instance->ReturnVal = cmock_to_return;\n"
     end
     lines << "  Mock.#{function[:name]}_IgnoreBool = (char)1;\n"
+    lines << "}\n\n"
+  
+    #add stop ignore function. it does not matter if there are any args
+    lines << "void #{function[:name]}_CMockStopIgnore(void)\n{\n"
+    lines << "  Mock.#{function[:name]}_IgnoreBool = (char)0;\n"
     lines << "}\n\n"
   end
 


### PR DESCRIPTION
Replying to the feature request Generate StopIgnore functions #303 added a StopIgnore() function to explicitly disable Ignore() if it has been set. 

I don't beleive it is necessary to have any returns as all this will do is set a flag.