### PR TITLE
Improve the regexps for parsing parameters to cmock.rb

### DIFF
--- a/lib/cmock.rb
+++ b/lib/cmock.rb
@@ -18,10 +18,12 @@ class CMock
     cm_config      = CMockConfig.new(options)
     cm_unityhelper = CMockUnityHelperParser.new(cm_config)
     cm_writer      = CMockFileWriter.new(cm_config)
-    cm_gen_utils   = CMockGeneratorUtils.new(cm_config, :unity_helper => cm_unityhelper)
+    cm_gen_utils   = CMockGeneratorUtils.new(cm_config,
+                                             :unity_helper => cm_unityhelper)
     cm_gen_plugins = CMockPluginManager.new(cm_config, cm_gen_utils)
     @cm_parser     = CMockHeaderParser.new(cm_config)
-    @cm_generator  = CMockGenerator.new(cm_config, cm_writer, cm_gen_utils, cm_gen_plugins)
+    @cm_generator  = CMockGenerator.new(cm_config, cm_writer, cm_gen_utils,
+                                        cm_gen_plugins)
     @silent        = (cm_config.verbosity < 2)
   end
 
@@ -85,12 +87,18 @@ if $0 == __FILE__
   options = {}
   filelist = []
   ARGV.each do |arg|
-    if arg =~ /^-o\"?([a-zA-Z0-9._\\\/:\s]+)\"?/
+    if (arg =~ /^-o\"?([a-zA-Z0-9@._\\\/:\s]+)\"?/)
       options.merge! CMockConfig.load_config_file_from_yaml(arg.gsub(/^-o/, ''))
-    elsif arg == '--skeleton'
+    elsif (arg == '--skeleton')
       options[:skeleton] = true
-    elsif arg =~ /^--([a-zA-Z0-9._\\\/:\s]+)=\"?([a-zA-Z0-9._\-\\\/:\s\;]+)\"?/
-      options = option_maker(options, Regexp.last_match(1), Regexp.last_match(2))
+    elsif (arg =~ /^--strippables=\"?(.*)\"?/)
+      # --strippables are dealt with separately since the user is allowed to
+      # enter any valid regular expression as argument
+      options = option_maker(options, 'strippables', Regexp.last_match(1))
+    elsif (arg =~ /^--([a-zA-Z0-9._\\\/:\s]+)=
+           \"?([a-zA-Z0-9._\-\\\/:\s\;]+)\"?/x)
+      options = option_maker(options, Regexp.last_match(1),
+                             Regexp.last_match(2))
     else
       filelist << arg
     end


### PR DESCRIPTION
Also, conform to the standard 80 character limit

This PR relates to [Issue 336](https://github.com/ThrowTheSwitch/CMock/issues/336)