### PR TITLE
Allow parsing empty values for options in CLI arguments

### DIFF
--- a/lib/cmock.rb
+++ b/lib/cmock.rb
@@ -89,7 +89,7 @@ if $0 == __FILE__
       options.merge! CMockConfig.load_config_file_from_yaml(arg.gsub(/^-o/, ''))
     elsif arg == '--skeleton'
       options[:skeleton] = true
-    elsif arg =~ /^--([a-zA-Z0-9._\\\/:\s]+)=\"?([a-zA-Z0-9._\-\\\/:\s\;]+)\"?/
+    elsif arg =~ /^--([a-zA-Z0-9._\\\/:\s]+)=\"?([a-zA-Z0-9._\-\\\/:\s\;]*)\"?/
       options = option_maker(options, Regexp.last_match(1), Regexp.last_match(2))
     else
       filelist << arg


### PR DESCRIPTION
If an option is passed via CLI, it cannot be passed with an
empty value because the Regex makes it to match 1 or more
characters.

For example, arguments `--mock_prefix=""` and `--mock_prefix=`
are invalid, because they don't match the regex and are not
recognized as options, so they're treated as files to mock.

Changing the regex to match 0 or more characters for the option
value, instead of 1 or more, solves the problem.