### PR TITLE
Fix static variables detection in headers for enabled inline function mocks

### DIFF
--- a/test/unit/cmock_header_parser_test.rb
+++ b/test/unit/cmock_header_parser_test.rb
@@ -2173,6 +2173,73 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
     assert_equal(expected, @parser.transform_inline_functions(source))
   end
 
+  it "Transform inline functions leaves static variables" do
+    source =
+      "#ifndef _NOINCLUDES\n" +
+      "#define _NOINCLUDES\n" +
+      "#include \"unity.h\"\n" +
+      "#include \"cmock.h\"\n" +
+      "#include \"YetAnotherHeader.h\"\n" +
+      "\n" +
+      "/* Ignore the following warnings since we are copying code */\n" +
+      "#if defined(__GNUC__) && !defined(__ICC) && !defined(__TMS470__)\n" +
+      "#if __GNUC__ > 4 || (__GNUC__ == 4 && (__GNUC_MINOR__ > 6 || (__GNUC_MINOR__ == 6 && __GNUC_PATCHLEVEL__ > 0)))\n" +
+      "#pragma GCC diagnostic push\n" +
+      "#endif\n" +
+      "#if !defined(__clang__)\n" +
+      "#pragma GCC diagnostic ignored \"-Wpragmas\"\n" +
+      "#endif\n" +
+      "#pragma GCC diagnostic ignored \"-Wunknown-pragmas\"\n" +
+      "#pragma GCC diagnostic ignored \"-Wduplicate-decl-specifier\"\n" +
+      "#endif\n" +
+      "\n" +
+      "int my_function(int a);\n" +
+      "static inline int staticinlinefunc(struct my_struct *s)\n" +
+      "{\n" +
+      "    return s->a;\n" +
+      "}\n" +
+      "static const int my_variable = 5;\n" +
+      "struct my_struct {\n" +
+      "int a;\n" +
+      "int b;\n" +
+      "int b;\n" +
+      "char c;\n" +
+      "};\n" +
+      "#endif _NOINCLUDES\n"
+
+    expected =
+    "#ifndef _NOINCLUDES\n" +
+    "#define _NOINCLUDES\n" +
+    "#include \"unity.h\"\n" +
+    "#include \"cmock.h\"\n" +
+    "#include \"YetAnotherHeader.h\"\n" +
+    "\n" +
+    "/* Ignore the following warnings since we are copying code */\n" +
+    "#if defined(__GNUC__) && !defined(__ICC) && !defined(__TMS470__)\n" +
+    "#if __GNUC__ > 4 || (__GNUC__ == 4 && (__GNUC_MINOR__ > 6 || (__GNUC_MINOR__ == 6 && __GNUC_PATCHLEVEL__ > 0)))\n" +
+    "#pragma GCC diagnostic push\n" +
+    "#endif\n" +
+    "#if !defined(__clang__)\n" +
+    "#pragma GCC diagnostic ignored \"-Wpragmas\"\n" +
+    "#endif\n" +
+    "#pragma GCC diagnostic ignored \"-Wunknown-pragmas\"\n" +
+    "#pragma GCC diagnostic ignored \"-Wduplicate-decl-specifier\"\n" +
+    "#endif\n" +
+    "\n" +
+    "int my_function(int a);\n" +
+    "int staticinlinefunc(struct my_struct *s);\n" +
+    "static const int my_variable = 5;\n" +
+    "struct my_struct {\n" +
+    "int a;\n" +
+    "int b;\n" +
+    "int b;\n" +
+    "char c;\n" +
+    "};\n" +
+    "#endif _NOINCLUDES\n"
+
+    assert_equal(expected, @parser.transform_inline_functions(source))
+  end
+
   it "Count number of pairs of braces in function succesfully" do
     source =
       "int foo(struct my_struct *s)\n" +


### PR DESCRIPTION
Should fix #313 and ThrowTheSwitch/Ceedling#541. Can also fix #338, but I can't reproduce it for presented example. Probably there is something more in the header than `#define CONSTANT_1 0x10` and inline function declaration.
I think @laurensmiers should create PR with this great change https://github.com/ThrowTheSwitch/CMock/commit/541e7034ad0e73b092514e888e17ba98b4facad7, before merging this PR.