### PR TITLE
Enable adding includes_h_pre_orig_header header if includes is def as []

### DIFF
--- a/lib/cmock_generator.rb
+++ b/lib/cmock_generator.rb
@@ -22,7 +22,8 @@ class CMockGenerator
     @exclude_setjmp_h = @config.exclude_setjmp_h
     @subdir = @config.subdir
 
-    @includes_h_pre_orig_header  = (@config.includes || @config.includes_h_pre_orig_header || []).map { |h| h =~ /</ ? h : "\"#{h}\"" }
+    @includes_h_pre_orig_header  = (@config.includes_h_pre_orig_header ||  []).map { |h| h =~ /</ ? h : "\"#{h}\"" }
+    @includes_h_pre_orig_header += (@config.includes || []).map { |h| h =~ /</ ? h : "\"#{h}\"" }
     @includes_h_post_orig_header = (@config.includes_h_post_orig_header || []).map { |h| h =~ /</ ? h : "\"#{h}\"" }
     @includes_c_pre_header       = (@config.includes_c_pre_header || []).map { |h| h =~ /</ ? h : "\"#{h}\"" }
     @includes_c_post_header      = (@config.includes_c_post_header || []).map { |h| h =~ /</ ? h : "\"#{h}\"" }

--- a/test/unit/cmock_generator_main_test.rb
+++ b/test/unit/cmock_generator_main_test.rb
@@ -48,7 +48,7 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
     @config.expect :enforce_strict_ordering, nil
     @config.expect :framework, :unity
     @config.expect :includes, ["ConfigRequiredHeader1.h","ConfigRequiredHeader2.h"]
-    #@config.expect :includes_h_pre_orig_header, nil #not called because includes called
+    @config.expect :includes_h_pre_orig_header, nil
     @config.expect :includes_h_post_orig_header, nil
     @config.expect :includes_c_pre_header, nil
     @config.expect :includes_c_post_header, nil


### PR DESCRIPTION
Hi

During moving part of my configuration from CMock to Ceedling, I noticed that adding to profile.yml:

```
:cmock:
  :mock_prefix: mock_
  :treat_inlines: :include
  :when_no_prototypes: :warn
  :enforce_strict_ordering: TRUE
  :weak: __attribute ((weak))
  :includes_h_pre_orig_header: 
    - zumzum.h
  :includes_c_pre_header: 
    - zumzum.h

```

Is not added to mock header files.
After investigation I noticed that the difference between using pure CMock and Ceedling is : 

@config:include  

In CMock I'm not defining this option as I'm not using it, but when I'm using Ceedling this part is set to empty array.

Basing on such information I started to look at:

`    @includes_h_pre_orig_header  = (@config.includes || @config.includes_h_pre_orig_header || []).map { |h| h =~ /</ ? h : "\"#{h}\"" }`

and what surprise me I noticed that:
- if @config.includes is [] -> then we didn't collect headers which we pass via includes_h_pre_orig_header option
- if @config.includes is nil -> everything works as it should

But I think, we should consider adding both options if they are defined by the end-user in profile.yml file.

To fix this I changed:

`    @includes_h_pre_orig_header  = (@config.includes || @config.includes_h_pre_orig_header || []).map { |h| h =~ /</ ? h : "\"#{h}\"" }`

to

```
    @includes_h_pre_orig_header  = (@config.includes ||  []).map { |h| h =~ /</ ? h : "\"#{h}\"" }
    @includes_h_pre_orig_header += (@config.includes_h_pre_orig_header || []).map { |h| h =~ /</ ? h : "\"#{h}\"" }

```
And everything right now for me is working as it should. The includes and pre_origin_headers are added in header files as I expect.

Problem was discovered at Ceedling:
```

    Ceedling:: 0.31.0
       CMock:: 2.5.3
       Unity:: 2.5.2
  CException:: 1.3.3
```