### PR TITLE
Switch places in the extern C regex to speed up mock generation

### DIFF
--- a/lib/cmock_header_parser.rb
+++ b/lib/cmock_header_parser.rb
@@ -245,8 +245,8 @@ class CMockHeaderParser
     source.gsub!(/__attribute(?:__)?\s*\(\(+.*\)\)+/, '')
 
     # remove preprocessor statements and extern "C"
-    source.gsub!(/^\s*#.*/, '')
     source.gsub!(/extern\s+\"C\"\s*\{/, '')
+    source.gsub!(/^\s*#.*/, '')
 
     # enums, unions, structs, and typedefs can all contain things (e.g. function pointers) that parse like function prototypes, so yank them
     # forward declared structs are removed before struct definitions so they don't mess up real thing later. we leave structs keywords in function prototypes


### PR DESCRIPTION
Hi,

Can I propose to switch regex places to speed up the time generation?
The sample recalculations I described in:
https://github.com/ThrowTheSwitch/CMock/issues/358

The time before changes:
real 0m16.431s
user 0m16.188s
sys 0m0.234s

after:
real 0m0.409s
user 0m0.188s
sys 0m0.219s

for file:
```
#ifndef ZUMZUM
#define ZUMZUM

#include <stddef.h>
#include <stdint.h>

#ifdef __cplusplus
#define NULLPTR 0
#define EXTERN_C_BEGIN extern "C"
{
#define EXTERN_C_END }
#else
#define NULLPTR (void *)NULL
#define EXTERN_C_BEGIN
#define EXTERN_C_END
#endif

#ifndef CHECK
# ifdef SOMETHING
#  if CHECK_SOMETHING == ZUMZUM_SOMETHING
#    define OMOM (1)
#  elif CHECK_SOMETHING == ZUMZUM_SOMETHING_EXTRA
#    define OMOM (2)
#  endif
# endif
#endif

void fun( void );

#endif
```