### PR TITLE
Fix parsing of calling conventions in function pointers

### DIFF
--- a/lib/cmock_header_parser.rb
+++ b/lib/cmock_header_parser.rb
@@ -495,7 +495,10 @@ class CMockHeaderParser
           funcname.gsub!('const', '').strip!
           funconst = 'const '
         end
-        parse_project[:typedefs] << "typedef #{funcret}(#{funcdecl} *#{functype})(#{funcargs});"
+        if funcdecl != ''
+          funcdecl += ' '
+        end
+        parse_project[:typedefs] << "typedef #{funcret}(#{funcdecl}*#{functype})(#{funcargs});"
         funcname = "cmock_arg#{c += 1}" if funcname.empty?
         "#{functype} #{funconst}#{funcname}"
       end

--- a/lib/cmock_header_parser.rb
+++ b/lib/cmock_header_parser.rb
@@ -484,17 +484,18 @@ class CMockHeaderParser
       arg_list.gsub!(/\*(\w)/, '* \1')
 
       # scan argument list for function pointers and replace them with custom types
-      arg_list.gsub!(/([\w\s\*]+)\(+\s*\*[\*\s]*([\w\s]*)\s*\)+\s*\(((?:[\w\s\*]*,?)*)\s*\)*/) do |_m|
+      arg_list.gsub!(/([\w\s\*]+)\(+([\w\s]*)\*[\*\s]*([\w\s]*)\s*\)+\s*\(((?:[\w\s\*]*,?)*)\s*\)*/) do |_m|
         functype = "cmock_#{parse_project[:module_name]}_func_ptr#{parse_project[:typedefs].size + 1}"
         funcret  = Regexp.last_match(1).strip
-        funcname = Regexp.last_match(2).strip
-        funcargs = Regexp.last_match(3).strip
+        funcdecl = Regexp.last_match(2).strip
+        funcname = Regexp.last_match(3).strip
+        funcargs = Regexp.last_match(4).strip
         funconst = ''
         if funcname.include? 'const'
           funcname.gsub!('const', '').strip!
           funconst = 'const '
         end
-        parse_project[:typedefs] << "typedef #{funcret}(*#{functype})(#{funcargs});"
+        parse_project[:typedefs] << "typedef #{funcret}(#{funcdecl} *#{functype})(#{funcargs});"
         funcname = "cmock_arg#{c += 1}" if funcname.empty?
         "#{functype} #{funconst}#{funcname}"
       end


### PR DESCRIPTION
Both Clang and MSVC compilers allow to use the following construct to place calling convention into function pointer
``` c
int (__cdecl * pfunc)(double arg);
```
However, CMock cannot swallow it, going into an infinite circle of pattern matching. I suggest to extend matching to cover this variant. This PR fixes https://github.com/ThrowTheSwitch/CMock/issues/373