### PR TITLE
Fix skeleton file creation

### DIFF
--- a/lib/cmock_generator.rb
+++ b/lib/cmock_generator.rb
@@ -134,7 +134,7 @@ class CMockGenerator
   def create_skeleton_source_file(mock_project)
     filename = "#{@config.mock_path}/#{@subdir + '/' if @subdir}#{mock_project[:module_name]}.c"
     existing = File.exist?(filename) ? File.read(filename) : ''
-    @file_writer.append_file(mock_project[:module_name] + '.c', @subdir) do |file, fullname|
+    @file_writer.create_file(mock_project[:module_name] + '.c', @subdir) do |file, fullname|
       blank_project = mock_project.clone
       blank_project[:parsed_stuff] = { :functions => [] }
       create_source_header_section(file, fullname, blank_project) if existing.empty?


### PR DESCRIPTION
Hi, Cmock maintainers! I was tesing the `--skeleton` option and  the resulting .c file was not being genereated. Messing around a little bit I found this solution. Just doing the same in `create_skeleton_source_file` than in `create_mock_source_file`. It works in my setup  (Windows 10, Ruby 3.0.3-1).

Thanks!!!