### PR TITLE
Fix runaway regex

### DIFF
--- a/lib/cmock_header_parser.rb
+++ b/lib/cmock_header_parser.rb
@@ -500,7 +500,7 @@ class CMockHeaderParser
       end
 
       # scan argument list for function pointers with shorthand notation and replace them with custom types
-      arg_list.gsub!(/([\w\s\*]+)+\s+(\w+)\s*\(((?:[\w\s\*]*,?)*)\s*\)*/) do |_m|
+      arg_list.gsub!(/([\w\s\*]+)\s+(\w+)\s*\(((?:[\w\s\*]*,?)*)\s*\)*/) do |_m|
         functype = "cmock_#{parse_project[:module_name]}_func_ptr#{parse_project[:typedefs].size + 1}"
         funcret  = Regexp.last_match(1).strip
         funcname = Regexp.last_match(2).strip


### PR DESCRIPTION
Multiple nested greedy quantifiers can cause to increase complexity of
the regular expression so that the matching in the cmock_header_parser
would take multiple minutes.
Fixed by removing one of the quantifiers that seems not to be needed.