### PR TITLE
Ensure alignment of CMock_Guts_Buffer

### DIFF
--- a/src/cmock.c
+++ b/src/cmock.c
@@ -25,8 +25,10 @@ static unsigned char*         CMock_Guts_Buffer = NULL;
 static CMOCK_MEM_INDEX_TYPE   CMock_Guts_BufferSize = CMOCK_MEM_ALIGN_SIZE;
 static CMOCK_MEM_INDEX_TYPE   CMock_Guts_FreePtr = CMOCK_MEM_ALIGN_SIZE;
 #else
-static unsigned char          CMock_Guts_Buffer[CMOCK_MEM_SIZE + CMOCK_MEM_ALIGN_SIZE];
-static CMOCK_MEM_INDEX_TYPE   CMock_Guts_BufferSize = CMOCK_MEM_SIZE + CMOCK_MEM_ALIGN_SIZE;
+static long long              CMock_Guts_Space[(CMOCK_MEM_SIZE + CMOCK_MEM_ALIGN_SIZE + sizeof(long long) - 1) /
+                                                sizeof(long long)];
+static unsigned char*         CMock_Guts_Buffer = (unsigned char *)CMock_Guts_Space;
+static CMOCK_MEM_INDEX_TYPE   CMock_Guts_BufferSize = sizeof(CMock_Guts_Space);
 static CMOCK_MEM_INDEX_TYPE   CMock_Guts_FreePtr = CMOCK_MEM_ALIGN_SIZE;
 #endif
 


### PR DESCRIPTION
Another attempt to fix something that was previously fixed by
73255670 but got reversed due to breaking something else.

The issue is that CMock_Guts_Buffer was unsigned char thus it
may have been unaligned (byte aligned). Portions from this buffer
where casted to a structure. On certain architectures alignment
must be maintained when accessing 32bit or 64 bit data and that
was not maintained with byte aligned array.

Instead of using attribute that may be complier specific, changing
type of array to long long.

Previous fix #172.
Fixes #66.

See #210 and revert commit: https://github.com/ThrowTheSwitch/CMock/commit/99c2223a1daa3877d306e585c80f16f2ba0842b7