### PR TITLE
Added extern "C" to cmock generated headers

### DIFF
--- a/lib/cmock_generator.rb
+++ b/lib/cmock_generator.rb
@@ -169,6 +169,10 @@ class CMockGenerator
     file << "#pragma GCC diagnostic ignored \"-Wduplicate-decl-specifier\"\n"
     file << "#endif\n"
     file << "\n"
+    file << "#ifdef __cplusplus\n"
+    file << "extern \"C\" {\n"
+    file << "#endif\n"
+    file << "\n"
   end
 
   def create_typedefs(file, mock_project)
@@ -184,6 +188,10 @@ class CMockGenerator
   end
 
   def create_mock_header_footer(header)
+    header << "\n"
+    header << "#ifdef __cplusplus\n"
+    header << "}\n"
+    header << "#endif\n"
     header << "\n"
     header << "#if defined(__GNUC__) && !defined(__ICC) && !defined(__TMS470__)\n"
     header << "#if __GNUC__ > 4 || (__GNUC__ == 4 && (__GNUC_MINOR__ > 6 || (__GNUC_MINOR__ == 6 && __GNUC_PATCHLEVEL__ > 0)))\n"

--- a/test/unit/cmock_generator_main_test.rb
+++ b/test/unit/cmock_generator_main_test.rb
@@ -123,6 +123,10 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
       "#pragma GCC diagnostic ignored \"-Wduplicate-decl-specifier\"\n",
       "#endif\n",
       "\n",
+      "#ifdef __cplusplus\n",
+      "extern \"C\" {\n",
+      "#endif\n",
+      "\n",
     ]
 
     @config.expect :orig_header_include_fmt, "#include \"%s\""
@@ -173,6 +177,10 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
       "#pragma GCC diagnostic ignored \"-Wduplicate-decl-specifier\"\n",
       "#endif\n",
       "\n",
+      "#ifdef __cplusplus\n",
+      "extern \"C\" {\n",
+      "#endif\n",
+      "\n",
     ]
 
     @config.expect :orig_header_include_fmt, "#include \"%s\""
@@ -217,6 +225,10 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
       "#pragma GCC diagnostic ignored \"-Wduplicate-decl-specifier\"\n",
       "#endif\n",
       "\n",
+      "#ifdef __cplusplus\n",
+      "extern \"C\" {\n",
+      "#endif\n",
+      "\n",
     ]
 
     @config.expect :orig_header_include_fmt, "#include \"%s\""
@@ -254,6 +266,10 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
       "#endif\n",
       "#pragma GCC diagnostic ignored \"-Wunknown-pragmas\"\n",
       "#pragma GCC diagnostic ignored \"-Wduplicate-decl-specifier\"\n",
+      "#endif\n",
+      "\n",
+      "#ifdef __cplusplus\n",
+      "extern \"C\" {\n",
       "#endif\n",
       "\n",
     ]
@@ -302,6 +318,10 @@ describe CMockGenerator, "Verify CMockGenerator Module" do
   it "append the proper footer to the header file" do
     output = []
     expected = ["\n",
+                "#ifdef __cplusplus\n",
+                "}\n",
+                "#endif\n",
+                "\n",
                 "#if defined(__GNUC__) && !defined(__ICC) && !defined(__TMS470__)\n",
                 "#if __GNUC__ > 4 || (__GNUC__ == 4 && (__GNUC_MINOR__ > 6 || (__GNUC_MINOR__ == 6 && __GNUC_PATCHLEVEL__ > 0)))\n",
                 "#pragma GCC diagnostic pop\n",


### PR DESCRIPTION
This allows the mock headers to be seamlessly used in cpp unit tests