### PR TITLE
Fix compiling native when main project is cross-compiling

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -6,7 +6,9 @@
 #
 cmock_dir = include_directories('.')
 
-cmock_lib = static_library(meson.project_name(), 
+cmock_lib = static_library(meson.project_name(),
     files('cmock.c'),
     dependencies: [unity_dep],
-    include_directories: cmock_dir)
+    include_directories: cmock_dir,
+    native: true,
+)


### PR DESCRIPTION
I am using this framework for unit testing and with that using meson. With meson i use this framework as a submodule and with the main meson project being cross-compiled it tried to cross-compile the framework as well, although the unittesting is done on the host machine. To fix this I added the native parameter to the the definition of the static library, so that that when used as a subproject in a crosscompiled project it will be used as a native instead of a cross project.

The submodule of Unity was updated to also include the changes of the native compilation there.