### PR TITLE
Allow the combination of use_test_preprocessor and CMock's treat_inlines

### DIFF
--- a/lib/cmock.rb
+++ b/lib/cmock.rb
@@ -27,9 +27,9 @@ class CMock
     @silent        = (cm_config.verbosity < 2)
   end
 
-  def setup_mocks(files, folder = nil)
+  def setup_mocks(files, orig_file = nil, folder = nil)
     [files].flatten.each do |src|
-      generate_mock(src, folder)
+      generate_mock(src, orig_file, folder)
     end
   end
 
@@ -41,11 +41,11 @@ class CMock
 
   private ###############################
 
-  def generate_mock(src, folder)
+  def generate_mock(src, orig_file, folder)
     name = File.basename(src, '.*')
     ext = File.extname(src)
     puts "Creating mock for #{name}..." unless @silent
-    @cm_generator.create_mock(name, @cm_parser.parse(name, File.read(src)), ext, folder)
+    @cm_generator.create_mock(name, @cm_parser.parse(name, File.read(src), orig_file), ext, folder)
   end
 
   def generate_skeleton(src)
@@ -106,6 +106,6 @@ if $0 == __FILE__
   if options[:skeleton]
     CMock.new(options).setup_skeletons(filelist)
   else
-    CMock.new(options).setup_mocks(filelist)
+    CMock.new(options).setup_mocks(filelist, "")
   end
 end

--- a/lib/cmock_header_parser.rb
+++ b/lib/cmock_header_parser.rb
@@ -29,7 +29,7 @@ class CMockHeaderParser
     @c_strippables += ['inline'] if @treat_inlines == :include # we'll need to remove the attribute if we're allowing inlines
   end
 
-  def parse(name, source)
+  def parse(name, source, orig_file)
     parse_project = {
       :module_name       => name.gsub(/\W/, ''),
       :typedefs          => [],
@@ -49,11 +49,17 @@ class CMockHeaderParser
       end
     end
 
-    parse_project[:normalized_source] = if @treat_inlines == :include
-                                          transform_inline_functions(source)
-                                        else
-                                          ''
-                                        end
+    if @treat_inlines == :include
+      if orig_file == nil
+        raise "Treat inlines is active but not-preprocessed original file is missing for " + name
+      elsif File.file?(orig_file)
+        # Run the inline transform on the original and never on the preprocessed source.
+        parse_project[:normalized_source] = transform_inline_functions(File.read(orig_file))
+      else
+        # CMock.rb directly calls with orig_file="". In this case restore the original behavior.
+        parse_project[:normalized_source] = transform_inline_functions(source)
+      end
+    end
 
     { :includes  => nil,
       :functions => parse_project[:functions],


### PR DESCRIPTION
I expect this combination to be pretty common especially in embedded unit testing. Often the preprocessor is needed because the vendor headers alone are too complex and tricky to be parsed correctly without preprocessing (NXP, STM, ...). Not to mention the own developed header files.

On the other hand you want to mock the evil inline functions that try to directly manipulate non existing registers. Even if you fake-map the registers into the host runner RAM you still have no control if the inline function was called or not. You gain a more fine grained control over your tests if the inline functions are mocked.

Unfortunately the combination of preprocessor and treat_inlines creates a copy of the original header in the include path which is stripped of all macros (=preprocessed). When the following GCC build of unit test itself is in anyway dependent on these macros the build will fail. This MR allows the specific mechanism of removing the static/inline keywords for the header copy to operate on the original file instead of the preprocessed file. While other operations of CMock run on the preprocessed file so there is no change in behaviour there.

I am not particular happy about this pull request concerning the code quality itself. It was my first touch with ruby/rake ever and I am just glad I achieved the level "works for us". Probably the tests need to be fixed. Probably there is a better or complete different way to resolve this. I just wanted to provide this to give an idea how it works. But I am also ready and willing to improve it, if you have some suggestions.

For more information compare the issue https://github.com/ThrowTheSwitch/Ceedling/issues/706

This PR is dependent on this PR: https://github.com/ThrowTheSwitch/Ceedling/pull/728