### PR TITLE
fix: Don't smush macros which have an escaped empty line at the end

### DIFF
--- a/lib/cmock_header_parser.rb
+++ b/lib/cmock_header_parser.rb
@@ -137,7 +137,7 @@ class CMockHeaderParser
     # If the user uses a macro to declare an inline function,
     # smushing the macros makes it easier to recognize them as a macro and if required,
     # remove them later on in this function
-    source.gsub!(/\s*\\\s*/m, ' ')
+    source.gsub!(/\s*\\(\n|\s*)/m, ' ')
 
     # Just looking for static|inline in the gsub is a bit too aggressive (functions that are named like this, ...), so we try to be a bit smarter
     # Instead, look for an inline pattern (f.e. "static inline") and parse it.

--- a/test/unit/cmock_header_parser_test.rb
+++ b/test/unit/cmock_header_parser_test.rb
@@ -2867,5 +2867,19 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
     assert_equal(expected, @parser.transform_inline_functions(source))
   end
 
+  it "Transform macros with escapes of empty lines" do
+    source =
+      "#define some_msg_t_FIELDLIST(X, a) \\\n" +
+      "\n" +
+      "#define some_msg_t_CALLBACK NULL\n"
+
+    expected =
+      "#define some_msg_t_FIELDLIST(X, a) \n" +
+      "#define some_msg_t_CALLBACK NULL\n"
+
+    @parser.treat_inlines = :include
+    assert_equal(expected, @parser.transform_inline_functions(source))
+  end
+
 
 end


### PR DESCRIPTION
[nanopb](https://github.com/nanopb/nanopb) has a habit of generating macros which end with an escaped empty line (for example for messages which are empty). They look like this:

    #define some_msg_t_FIELDLIST(X, a) \

    #define some_msg_t_CALLBACK NULL

This caused CMock to strip all of the newlines after the backslash instead of only one, which the backslash was escaping. This in turn caused both the macros to be in one line, causing a compile error in the generated mock.