### PR TITLE
Added support for noreturn mocked function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Gemfile.lock
 *.swp
 examples/make_example/build
 examples/temp_sensor/build
+*~

--- a/docs/CMock_Summary.md
+++ b/docs/CMock_Summary.md
@@ -82,6 +82,7 @@ replied with a version that is older than 2.0.0. Go ahead. We'll wait.
 Once you have Ruby, you have three options:
 
 * Clone the latest [CMock repo on github](https://github.com/ThrowTheSwitch/CMock/)
+  (This includes updating the submodules: `git submodules update`)
 * Download the latest [CMock zip from github](https://github.com/ThrowTheSwitch/CMock/)
 * Install Ceedling (which has it built in!) through your commandline using `gem install ceedling`.
 
@@ -135,7 +136,7 @@ that resembles a pointer or array, it breaks the argument into TWO arguments.
 The first is the original pointer. The second specify the number of elements
 it is to verify of that array. If you specify 1, it'll check one object. If 2,
 it'll assume your pointer is pointing at the first of two elements in an array.
-If you specify zero elements and `UNITY_COMPARE_PTRS_ON_ZERO_ARRAY` is defined, 
+If you specify zero elements and `UNITY_COMPARE_PTRS_ON_ZERO_ARRAY` is defined,
 then this assertion can also be used to directly compare the pointers to verify
 that they are pointing to the same memory address.
 
@@ -384,6 +385,38 @@ from the defaults. We've tried to specify what the defaults are below.
   * defaults: ['__ramfunc', '__irq', '__fiq', 'register', 'extern']
   * **note:** this option will reinsert these attributes onto the mock's calls.
     If that isn't what you are looking for, check out :strippables.
+
+* `:process_cpp_attributes`:
+  Allows the parsing and processing of C++ attribute syntax `[[...]]`.
+
+  * defaults: false
+
+* `:process_gcc_attributes`:
+  Allows the parsing and processing of GNU gcc attribute syntax
+  `__attribute__ ((...))`.
+  When setting it to true, mind removing `__attribute__` from the
+  `:strippables`` option.
+  Those attributes are matched both before and after the function name.
+
+  * defaults: false
+
+* `:noreturn_attributes`:
+    To allow processing of noreturn attributes, list in
+    `:noreturn_attributes` the keywords used as noreturn attributes.
+    (Since such attributes may hide behind macros, you may need to list
+    the macros too).
+>  :noreturn_attributes => ['_Noreturn', 'noreturn', '__noreturn__']
+	Note: when a keyword is listed in this option, it's available for
+    both the C syntax (keyword standing alone), the C++ syntax (keyword
+    in a `[[...]]` syntax, and the GNU gcc syntax (keyword in a
+    `__attribute__((...))` syntax)
+    When a noreturn attribute is matched, the returned function
+    dictionary will contain a :noreturn => true` entry, and the cmock
+    code generator will then avoid returning from the mocked function,
+    but instead will use the `TEST_DO_NOT_RETURN()` macro.
+
+  * defaults: []
+
 
 * `:c_calling_conventions`:
   Similarly, CMock may need to understand which C calling conventions

--- a/lib/CLexer.rb
+++ b/lib/CLexer.rb
@@ -1,0 +1,153 @@
+#
+# This is a simple lexer for the C programming language. 
+# MIT license. (c) 2023 Pascal Bourguignon
+#
+
+class CLexer
+
+  KEYWORDS = %w[auto break case char const continue default do double else enum
+                extern float for goto if int long register return short signed
+                sizeof static struct switch typedef union unsigned void volatile while].freeze
+
+  STAR = :mul_op
+  ADDRESS = :logical_and_op
+
+  OPERATOR_SYMBOLS = {
+
+    '...' => :ellipsis,
+    '->*' => :ptr_mem_op,
+    '>>=' => :right_assign,
+    '<<=' => :left_assign,
+
+    '==' => :eq,
+    '!=' => :ne,
+    '<=' => :le,
+    '>=' => :ge,
+    '>>' => :right_op,
+    '<<' => :left_op,
+    '+=' => :add_assign,
+    '-=' => :sub_assign,
+    '*=' => :mul_assign,
+    '/=' => :div_assign,
+    '%=' => :mod_assign,
+    '&=' => :and_assign,
+    '^=' => :xor_assign,
+    '|=' => :or_assign,
+    '->' => :ptr_op,
+    '&&' => :and_op,
+    '||' => :or_op,
+    '++' => :increment,
+    '--' => :decrement,
+
+    '<:' => :open_bracket,
+    ':>' => :close_bracket,
+    '<%' => :open_brace,
+    '%>' => :close_brace,
+
+    '!' => :logical_not_op,
+    '%' => :mod_op,
+    '&' => :logical_and_op,
+    '(' => :open_paren,
+    ')' => :close_paren,
+    '*' => :mul_op,
+    '+' => :add_op,
+    ',' => :comma,
+    '-' => :sub_op,
+    '.' => :dot,
+    '/' => :div_op,
+    ':' => :colon,
+    ';' => :semicolon,
+    '<' => :lt,
+    '=' => :assign,
+    '>' => :gt,
+    '?' => :question,
+    '[' => :open_bracket,
+    ']' => :close_bracket,
+    '^' => :logical_xor_op,
+    '{' => :open_brace,
+    '|' => :logical_or_op,
+    '}' => :close_brace,
+    '~' => :bitwise_not_op,
+
+  }.freeze
+
+
+  OPERATOR_REGEX = Regexp.new('\A(' + OPERATOR_SYMBOLS.keys.map { |op| Regexp.escape(op) }.join('|') + ')')
+  OPERATOR_SYMS = OPERATOR_SYMBOLS.values.freeze
+  KEYWORDS_SYMS = KEYWORDS.map{ |n| n.to_sym }.freeze
+
+  def initialize(input)
+    @input = input
+    @tokens = []
+  end
+
+  def tokenize
+    while @input.size > 0
+      case @input
+      when /\A[[:space:]]+/m
+        @input = $'
+      when /\A\/\/[^\n]*/
+        @input = $'
+      when /\A\/\*/
+        consume_multiline_comment
+      when /\A[_a-zA-Z][_a-zA-Z0-9]*/
+        identifier_or_keyword = $& ;
+        @input = $'
+        if KEYWORDS.include?(identifier_or_keyword)
+          @tokens << identifier_or_keyword.to_sym
+        else
+          @tokens << [:identifier, identifier_or_keyword]
+        end
+      when /\A\d+\.\d*([eE][+-]?\d+)?[fFlL]?|\.\d+([eE][+-]?\d+)?[fFlL]?|\d+[eE][+-]?\d+[fFlL]?/
+        float_constant = $& ;
+        @input = $'
+        @tokens << [:float_literal, float_constant]
+      when /\A\d+/
+        integer_constant = $& ;
+        @input = $'
+        @tokens << [:integer_literal, integer_constant]
+      when /\A0[xX][0-9a-fA-F]+/
+        hex_constant = $& ;
+        @input = $'
+        @tokens << [:hex_literal, hex_constant]
+      when /\A'((\\.|[^\\'])*)'/
+        char_literal = $& ;
+        @input = $'
+        @tokens << [:char_literal, char_literal]
+      when /\A"((\\.|[^\\"])*)"/
+        string_literal = $& ;
+        @input = $'
+        @tokens << [:string_literal, string_literal]
+      when OPERATOR_REGEX
+        operator = $& ;
+        @input = $'
+        @tokens << OPERATOR_SYMBOLS[operator]
+      else
+        raise "Unexpected character: #{@input[0]}"
+      end
+    end
+
+    @tokens
+  end
+
+  private
+
+  def consume_multiline_comment
+    while @input.size > 0
+      case @input
+      when /\A\*\//
+        @input = $'
+        break
+      when /\A./m
+        @input = $'
+      end
+    end
+  end
+end
+
+def example 
+  input = File.read("/home/pbourguignon/src/c-tidbits/pipes/tee.out.c")
+  lexer = CLexer.new(input)
+  tokens = lexer.tokenize
+  puts tokens.inspect
+end

--- a/lib/cmock_config.rb
+++ b/lib/cmock_config.rb
@@ -35,6 +35,7 @@ class CMockConfig
       :treat_inlines               => :exclude,        # the options being :include or :exclude
       :callback_include_count      => true,
       :callback_after_arg_check    => false,
+      :callback_kind               => "*",
       :includes                    => nil,
       :includes_h_pre_orig_header  => nil,
       :includes_h_post_orig_header => nil,

--- a/lib/cmock_config.rb
+++ b/lib/cmock_config.rb
@@ -18,11 +18,8 @@ class CMockConfig
       :strippables                 => ['(?:__attribute__\s*\([ (]*.*?[ )]*\)+)'],
       :process_gcc_attributes      => false, # __attribute__((...)) ; also remove it from strippables.
       :process_cpp_attributes      => false, # [[ ... ]] 
+      :noreturn_attributes         => [], # simple keyword, before the function name
       :attributes                  => %w[__ramfunc __irq __fiq register extern],
-      :c_noreturn_attributes       => [], # simple keyword, before the function name
-      :gcc_noreturn_attributes     => [], # put 'noreturn' for __attribute__((noreturn)), 
-      #                                   # before or after the function name,
-      #                                   # also remove it from :strippables
       :c_calling_conventions       => %w[__stdcall __cdecl __fastcall],
       :enforce_strict_ordering     => false,
       :fail_on_unexpected_calls    => true,

--- a/lib/cmock_config.rb
+++ b/lib/cmock_config.rb
@@ -16,7 +16,13 @@ class CMockConfig
       :subdir                      => nil,
       :plugins                     => [],
       :strippables                 => ['(?:__attribute__\s*\([ (]*.*?[ )]*\)+)'],
+      :process_gcc_attributes      => false, # __attribute__((...)) ; also remove it from strippables.
+      :process_cpp_attributes      => false, # [[ ... ]] 
       :attributes                  => %w[__ramfunc __irq __fiq register extern],
+      :c_noreturn_attributes       => [], # simple keyword, before the function name
+      :gcc_noreturn_attributes     => [], # put 'noreturn' for __attribute__((noreturn)), 
+      #                                   # before or after the function name,
+      #                                   # also remove it from :strippables
       :c_calling_conventions       => %w[__stdcall __cdecl __fastcall],
       :enforce_strict_ordering     => false,
       :fail_on_unexpected_calls    => true,

--- a/lib/cmock_generator.rb
+++ b/lib/cmock_generator.rb
@@ -90,11 +90,7 @@ class CMockGenerator
   private if $ThisIsOnlyATest.nil? ##############################
 
   def is_noreturn?(function)
-    if function[:attributes].nil?
-      return nil;
-    else
-	  return function[:attributes].include?('noreturn');
-    end
+    function[:noreturn]
   end
 
   def generate_return(function)

--- a/lib/cmock_generator.rb
+++ b/lib/cmock_generator.rb
@@ -89,6 +89,34 @@ class CMockGenerator
 
   private if $ThisIsOnlyATest.nil? ##############################
 
+  def is_noreturn?(function)
+    if function[:attributes].nil?
+      return nil;
+    else
+	  return function[:attributes].include?('noreturn');
+    end
+  end
+
+  def generate_return(function)
+    if is_noreturn?(function)
+      return "  TEST_DO_NOT_RETURN();\n"
+    elsif function[:return][:void?]
+      return "  return;\n"
+    else
+      return "  return cmock_call_instance->ReturnVal;\n"
+    end
+  end
+
+  def generate_template_return(function)
+    if is_noreturn?(function)
+      return "  TEST_DO_NOT_RETURN();\n"
+    elsif function[:return][:void?]
+      return "  return;\n"
+    else
+      return "  return (#{(function[:return][:type])})0;\n"
+    end
+  end
+
   def create_mock_subdir(mock_project)
     @file_writer.create_subdir(mock_project[:folder])
   end
@@ -342,7 +370,7 @@ class CMockGenerator
     end
     file << @plugins.run(:mock_implementation, function)
     file << "  UNITY_CLR_DETAILS();\n"
-    file << "  return cmock_call_instance->ReturnVal;\n" unless function[:return][:void?]
+    file << generate_return(function);
     file << "}\n"
 
     # Close any namespace(s) opened above
@@ -374,7 +402,7 @@ class CMockGenerator
     file << "{\n"
     file << "  /*TODO: Implement Me!*/\n"
     function[:args].each { |arg| file << "  (void)#{arg[:name]};\n" }
-    file << "  return (#{(function[:return][:type])})0;\n" unless function[:return][:void?]
+    file << generate_template_return(function);
     file << "}\n\n"
   end
 end

--- a/lib/cmock_generator_plugin_callback.rb
+++ b/lib/cmock_generator_plugin_callback.rb
@@ -27,10 +27,11 @@ class CMockGeneratorPluginCallback
   def mock_function_declarations(function)
     func_name = function[:name]
     return_type = function[:return][:type]
+    kind   = @config.callback_kind.nil? ? '*' : @config.callback_kind
     action = @config.callback_after_arg_check ? 'AddCallback' : 'Stub'
     style  = (@include_count ? 1 : 0) | (function[:args].empty? ? 0 : 2)
     styles = ['void', 'int cmock_num_calls', function[:args_string], "#{function[:args_string]}, int cmock_num_calls"]
-    "typedef #{return_type} (* CMOCK_#{func_name}_CALLBACK)(#{styles[style]});\n" \
+    "typedef #{return_type} (#{kind} CMOCK_#{func_name}_CALLBACK)(#{styles[style]});\n" \
     "void #{func_name}_AddCallback(CMOCK_#{func_name}_CALLBACK Callback);\n" \
     "void #{func_name}_Stub(CMOCK_#{func_name}_CALLBACK Callback);\n" \
     "#define #{func_name}_StubWithCallback #{func_name}_#{action}\n"

--- a/test/rakefile_helper.rb
+++ b/test/rakefile_helper.rb
@@ -21,7 +21,7 @@ module RakefileHelpers
 
   def load_configuration(config_file)
     $cfg_file = config_file
-    $cfg = YAML.load(File.read('./targets/' + $cfg_file))
+    $cfg = YAML.load(File.read('./targets/' + $cfg_file),aliases: true)
     $colour_output = false unless $cfg['colour']
   end
 

--- a/test/system/test_compilation/config.yml
+++ b/test/system/test_compilation/config.yml
@@ -8,3 +8,7 @@
   :treat_as_void:
   - OSEK_TASK
   - VOID_TYPE_CRAZINESS
+  :strippables: []
+  :process_gcc_attributes: true
+  :noreturn_attributes: ['_Noreturn','noreturn']
+  

--- a/test/system/test_compilation/noreturn.h
+++ b/test/system/test_compilation/noreturn.h
@@ -1,0 +1,9 @@
+#ifndef noreturn_h
+#define noreturn_h
+/* #include <stdnoreturn.h> */
+
+_Noreturn void myexec1(const char* program);
+void __attribute__((noreturn)) myexec2(const char* program);
+void myexec3(const char* program) __attribute__((noreturn));
+
+#endif

--- a/test/unit/cmock_header_parser_test.rb
+++ b/test/unit/cmock_header_parser_test.rb
@@ -18,9 +18,9 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
     @config.expect :strippables, ["STRIPPABLE"]
     @config.expect :attributes, ['__ramfunc', 'funky_attrib', 'SQLITE_API','access','rt::access','deprecated']
     @config.expect :c_calling_conventions, ['__stdcall']
-	@config.expect :c_noreturn_attributes,['_Noreturn', 'noreturn', '__noreturn__']
     @config.expect :process_gcc_attributes, true
     @config.expect :process_cpp_attributes, true
+	@config.expect :noreturn_attributes,['_Noreturn', 'noreturn', '__noreturn__']
     @config.expect :treat_as_void, ['MY_FUNKY_VOID']
     @config.expect :treat_as, { "BANJOS" => "INT", "TUBAS" => "HEX16"}
     @config.expect :treat_as_array, {"IntArray" => "int", "Book" => "Page"}
@@ -3127,7 +3127,7 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                               :str    => "int cmock_to_return",
                               :void?  => false
                             },
-                 :modifier => "_Noreturn",
+                 :modifier => "",
                  :contains_ptr? => false,
                  :args => [ {:type => "int", :name => "a", :ptr? => false, :const? => false, :const_ptr? => false},
                             {:type => "unsigned int", :name => "b", :ptr? => false, :const? => false, :const_ptr? => false}
@@ -3153,7 +3153,7 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                               :str    => "int cmock_to_return",
                               :void?  => false
                             },
-                 :modifier => "noreturn",
+                 :modifier => "",
                  :contains_ptr? => false,
                  :args => [ {:type => "int", :name => "a", :ptr? => false, :const? => false, :const_ptr? => false},
                             {:type => "unsigned int", :name => "b", :ptr? => false, :const? => false, :const_ptr? => false}
@@ -3179,7 +3179,7 @@ describe CMockHeaderParser, "Verify CMockHeaderParser Module" do
                               :str    => "int cmock_to_return",
                               :void?  => false
                             },
-                 :modifier => "[[noreturn]]",
+                 :modifier => "",
                  :contains_ptr? => false,
                  :args => [ {:type => "int", :name => "a", :ptr? => false, :const? => false, :const_ptr? => false},
                             {:type => "unsigned int", :name => "b", :ptr? => false, :const? => false, :const_ptr? => false}


### PR DESCRIPTION
```
Hi!

Here's a (somewhat big) patch to support and mock **noreturn** functions.

Functions may be declared as noreturn with various syntaxes (_Noreturn, noreturn, __attribute__((noreturn)), [[noreturn]] etc).
When that's the case, trying to return from them is undefined, and some compilers such as clang will warn or error about these mocked functions.

Therefore, the proposed patches has three parts:
- added to **Unity** a set of macros:  TEST_PROTECT_NORETURN(), TEST_DO_NOT_RETURN(), and TEST_NOT_RETURNING(call) to test for non-returning functions. (cf. https://github.com/ThrowTheSwitch/Unity/pull/674 )
- `cmock_generator.rb` checks for the `function[:noreturn]` flag, and when set, generates calls to the new `TEST_DO_NOT_RETURN()` macro.
- `cmock_header_parser.rb` now perform some level of parsing to analyse the noreturn attributes.

There's a C lexer (`CLexer`) that is used to transform source text into Arrays of Symbols, which are then parsed to get the parenthesis structure correctly (parentheses, brackets, braces and angle brackets for C++ templates).  This "structured" Array of Symbol is the processed to parse the function signature, along with any attribute surrounding it, or in the parameters. (namespaces in C++ [[ ... ]] attributes are supported too).  Most attributes are thrown away, but noreturn attributes are used to set the resulting function[:noreturn] flag used by the generator.

All the old unit and integration tests pass (mostly unchanged, a few results are different, eg. __attribute__ are not removed early, or int const* --> const int* because the text are unparsed from internal representations).

New unit tests for new noreturn code is added, as well as a noreturn.h for integration test (system). I've not found any "test driver" for them so I assumed that the test only processed them automatically,without actually running a mock test (but it would be nice to add one, since we may want to test the TEST_PROTECT_NORETURN() and  TEST_NOT_RETURNING(myexec1("test")) macros. 

```