### PR TITLE
Add plugin to validate address of ptr_args

### DIFF
--- a/lib/cmock_generator_plugin_validate_ptr_address.rb
+++ b/lib/cmock_generator_plugin_validate_ptr_address.rb
@@ -1,0 +1,73 @@
+class CMockGeneratorPluginValidatePtrAddress
+  attr_reader :priority
+  attr_accessor :utils
+
+  def initialize(config, utils)
+    @utils        = utils
+    @priority     = 4
+  end
+
+  def instance_typedefs(function)
+    lines = ""
+    function[:args].each do |arg|
+      if (@utils.ptr_or_str?(arg[:type]) and not arg[:const?])
+        lines << "  int ValidateAddressArg_#{arg[:name]};\n"
+      end
+    end
+    lines
+  end
+
+  def mock_function_declarations(function)
+    lines = ""
+    function[:args].each do |arg|
+      if (@utils.ptr_or_str?(arg[:type]) and not arg[:const?])
+        lines << "#define #{function[:name]}_ValidateAddress_#{arg[:name]}()"
+        lines << " #{function[:name]}_CMockValidateAddress_#{arg[:name]}(__LINE__)\n"
+        lines << "void #{function[:name]}_CMockValidateAddress_#{arg[:name]}(UNITY_LINE_TYPE cmock_line);\n"
+      end
+    end
+    lines
+  end
+
+  def mock_interfaces(function)
+    lines = []
+    func_name = function[:name]
+    function[:args].each do |arg|
+      arg_name = arg[:name]
+      arg_type = arg[:type]
+      if (@utils.ptr_or_str?(arg[:type]) and not arg[:const?])
+        lines << "void #{func_name}_CMockValidateAddress_#{arg_name}(UNITY_LINE_TYPE cmock_line)\n"
+        lines << "{\n"
+        lines << "  CMOCK_#{func_name}_CALL_INSTANCE* cmock_call_instance = " +
+          "(CMOCK_#{func_name}_CALL_INSTANCE*)CMock_Guts_GetAddressFor(CMock_Guts_MemEndOfChain(Mock.#{func_name}_CallInstance));\n"
+        lines << "  UNITY_TEST_ASSERT_NOT_NULL(cmock_call_instance, cmock_line, CMockStringPtrPreExp);\n"
+        lines << "  cmock_call_instance->ValidateAddressArg_#{arg_name} = 1;\n"
+        lines << "}\n\n"
+      end
+    end
+    lines
+  end
+
+  def mock_implementation(function)
+    lines = []
+    function[:args].each do |arg|
+      arg_name = arg[:name]
+      arg_type = arg[:type]
+      expected   = "cmock_call_instance->Expected_#{arg_name}"
+      if (@utils.ptr_or_str?(arg[:type]) and not arg[:const?])
+        lines << "  if (cmock_call_instance->ValidateAddressArg_#{arg_name})\n"
+        lines << "  {\n"
+        lines << "    if (#{expected} == NULL)\n"
+        lines << "    {\n"
+        lines << "      UNITY_TEST_ASSERT_NULL(#{arg_name}, cmock_line, CMockStringExpNULL);\n"
+        lines << "    }\n"
+        lines << "    else\n"
+        lines << "    {\n"
+        lines << "      UNITY_TEST_ASSERT_EQUAL_PTR(#{expected}, #{arg_name}, cmock_line, CMockStringMismatch);\n"
+        lines << "    }\n"
+        lines << "  }\n"
+      end
+    end
+    lines
+  end
+end

--- a/lib/cmock_generator_utils.rb
+++ b/lib/cmock_generator_utils.rb
@@ -16,6 +16,7 @@ class CMockGeneratorUtils
     @expect_any   = @config.plugins.include? :expect_any_args
     @return_thru_ptr = @config.plugins.include? :return_thru_ptr
     @ignore_arg = @config.plugins.include? :ignore_arg
+    @validate_ptr_address   = @config.plugins.include? :validate_ptr_address
     @ignore = @config.plugins.include? :ignore
     @ignore_stateless = @config.plugins.include? :ignore_stateless
     @treat_as = @config.treat_as
@@ -64,6 +65,7 @@ class CMockGeneratorUtils
   def code_add_an_arg_expectation(arg, depth = 1)
     lines =  code_assign_argument_quickly("cmock_call_instance->Expected_#{arg[:name]}", arg)
     lines << "  cmock_call_instance->Expected_#{arg[:name]}_Depth = #{arg[:name]}_Depth;\n" if @arrays && (depth.class == String)
+    lines << "  cmock_call_instance->ValidateAddressArg_#{arg[:name]} = 0;\n" if (@validate_ptr_address and ptr_or_str?(arg[:type]) and not arg[:const?])
     lines << "  cmock_call_instance->IgnoreArg_#{arg[:name]} = 0;\n" if @ignore_arg
     lines << "  cmock_call_instance->ReturnThruPtr_#{arg[:name]}_Used = 0;\n" if @return_thru_ptr && ptr_or_str?(arg[:type]) && !(arg[:const?])
     lines


### PR DESCRIPTION
I made this plugin for a local instance of CMock a while ago, and though I'd see if there was interest in adding in general. If there is interest in it, I'll add tests and documentation for it.

Adds functions to validate the address of ptr_args when not interested in the content of the ptr, but want to validate the address is as expected.