### PR TITLE
Added a user-friendly error message when processing bad :treat_as

### DIFF
--- a/lib/cmock_unityhelper_parser.rb
+++ b/lib/cmock_unityhelper_parser.rb
@@ -35,6 +35,9 @@ class CMockUnityHelperParser
   def map_c_types
     c_types = {}
     @config.treat_as.each_pair do |ctype, expecttype|
+      if ctype.is_a?(Symbol)
+        raise ":treat_as expects a list of  identifier: identifier  mappings, but got a symbol: #{ctype}. Check the indentation in your project.yml"
+      end
       c_type = ctype.gsub(/\s+/, '_')
       if expecttype =~ /\*/
         c_types[c_type] = "UNITY_TEST_ASSERT_EQUAL_#{expecttype.delete('*')}_ARRAY"


### PR DESCRIPTION
When the indentation after :treat_as mappings is wrong, we may get a symbol as ctype. The error signaled by gtype.gsub is not userfriendly, so instead, we test for symbols and issue a user friend error message in that case.