### PR TITLE
Make ReturnMemThruPtr pointers const

### DIFF
--- a/lib/cmock_generator_plugin_return_thru_ptr.rb
+++ b/lib/cmock_generator_plugin_return_thru_ptr.rb
@@ -7,13 +7,18 @@ class CMockGeneratorPluginReturnThruPtr
     @priority     = 9
   end
 
+  def ptr_to_const(arg_type)
+    # replace last "*" with " const*"
+    arg_type.gsub(/(.*)\*/, '\1 const*')
+  end
+
   def instance_typedefs(function)
     lines = ''
     function[:args].each do |arg|
       next unless @utils.ptr_or_str?(arg[:type]) && !(arg[:const?])
 
       lines << "  char ReturnThruPtr_#{arg[:name]}_Used;\n"
-      lines << "  #{arg[:type]} ReturnThruPtr_#{arg[:name]}_Val;\n"
+      lines << "  #{ptr_to_const(arg[:type])} ReturnThruPtr_#{arg[:name]}_Val;\n"
       lines << "  size_t ReturnThruPtr_#{arg[:name]}_Size;\n"
     end
     lines
@@ -36,7 +41,7 @@ class CMockGeneratorPluginReturnThruPtr
       lines << " #{function[:name]}_CMockReturnMemThruPtr_#{arg[:name]}(__LINE__, #{arg[:name]}, cmock_len * sizeof(*#{arg[:name]}))\n"
       lines << "#define #{function[:name]}_ReturnMemThruPtr_#{arg[:name]}(#{arg[:name]}, cmock_size)"
       lines << " #{function[:name]}_CMockReturnMemThruPtr_#{arg[:name]}(__LINE__, #{arg[:name]}, cmock_size)\n"
-      lines << "void #{function[:name]}_CMockReturnMemThruPtr_#{arg[:name]}(UNITY_LINE_TYPE cmock_line, #{arg[:type]} #{arg[:name]}, size_t cmock_size);\n"
+      lines << "void #{function[:name]}_CMockReturnMemThruPtr_#{arg[:name]}(UNITY_LINE_TYPE cmock_line, #{ptr_to_const(arg[:type])} #{arg[:name]}, size_t cmock_size);\n"
     end
     lines
   end
@@ -48,7 +53,7 @@ class CMockGeneratorPluginReturnThruPtr
       arg_name = arg[:name]
       next unless @utils.ptr_or_str?(arg[:type]) && !(arg[:const?])
 
-      lines << "void #{func_name}_CMockReturnMemThruPtr_#{arg_name}(UNITY_LINE_TYPE cmock_line, #{arg[:type]} #{arg_name}, size_t cmock_size)\n"
+      lines << "void #{func_name}_CMockReturnMemThruPtr_#{arg_name}(UNITY_LINE_TYPE cmock_line, #{ptr_to_const(arg[:type])} #{arg_name}, size_t cmock_size)\n"
       lines << "{\n"
       lines << "  CMOCK_#{func_name}_CALL_INSTANCE* cmock_call_instance = " \
                "(CMOCK_#{func_name}_CALL_INSTANCE*)CMock_Guts_GetAddressFor(CMock_Guts_MemEndOfChain(Mock.#{func_name}_CallInstance));\n"
@@ -70,7 +75,7 @@ class CMockGeneratorPluginReturnThruPtr
       lines << "  if (cmock_call_instance->ReturnThruPtr_#{arg_name}_Used)\n"
       lines << "  {\n"
       lines << "    UNITY_TEST_ASSERT_NOT_NULL(#{arg_name}, cmock_line, CMockStringPtrIsNULL);\n"
-      lines << "    memcpy((void*)#{arg_name}, (void*)cmock_call_instance->ReturnThruPtr_#{arg_name}_Val,\n"
+      lines << "    memcpy((void*)#{arg_name}, (const void*)cmock_call_instance->ReturnThruPtr_#{arg_name}_Val,\n"
       lines << "      cmock_call_instance->ReturnThruPtr_#{arg_name}_Size);\n"
       lines << "  }\n"
     end

--- a/test/unit/cmock_generator_plugin_return_thru_ptr_test.rb
+++ b/test/unit/cmock_generator_plugin_return_thru_ptr_test.rb
@@ -21,7 +21,7 @@ describe CMockGeneratorPluginReturnThruPtr, "Verify CMockGeneratorPluginReturnTh
                     :return  => test_return[:string],
                     :contains_ptr? => false}
 
-    # void Pine(int chicken, const int beef, int *tofu)
+    # void Pine(int chicken, const int beef, int *tofu, const char** buffer)
     @complex_func = {:name => "Pine",
                      :args => [{ :type => "int",
                                  :name => "chicken",
@@ -34,6 +34,10 @@ describe CMockGeneratorPluginReturnThruPtr, "Verify CMockGeneratorPluginReturnTh
                                },
                                { :type => "int*",
                                  :name => "tofu",
+                                 :ptr? => true,
+                               },
+                               { :type => "char**",
+                                 :name => "bean_buffer",
                                  :ptr? => true,
                                }],
                      :return => test_return[:void],
@@ -54,6 +58,7 @@ describe CMockGeneratorPluginReturnThruPtr, "Verify CMockGeneratorPluginReturnTh
     @utils.expect :ptr_or_str?, false, ['int']
     @utils.expect :ptr_or_str?, true, ['const int*']
     @utils.expect :ptr_or_str?, true, ['int*']
+    @utils.expect :ptr_or_str?, true, ['char**']
   end
 
   it "have set up internal priority correctly on init" do
@@ -69,11 +74,14 @@ describe CMockGeneratorPluginReturnThruPtr, "Verify CMockGeneratorPluginReturnTh
     assert_equal("", returned)
   end
 
-  it "add to tyepdef structure mock needs of functions of style 'void func(int chicken, int* pork)'" do
+  it "add to tyepdef structure mock needs of functions of style 'void func(int chicken, const int beef, int* pork, char** bean_buffer)'" do
     complex_func_expect()
     expected = "  char ReturnThruPtr_tofu_Used;\n" +
-               "  int* ReturnThruPtr_tofu_Val;\n" +
-               "  size_t ReturnThruPtr_tofu_Size;\n"
+               "  int const* ReturnThruPtr_tofu_Val;\n" +
+               "  size_t ReturnThruPtr_tofu_Size;\n" +
+               "  char ReturnThruPtr_bean_buffer_Used;\n" +
+               "  char* const* ReturnThruPtr_bean_buffer_Val;\n" +
+               "  size_t ReturnThruPtr_bean_buffer_Size;\n"
     returned = @cmock_generator_plugin_return_thru_ptr.instance_typedefs(@complex_func)
     assert_equal(expected, returned)
   end
@@ -94,7 +102,14 @@ describe CMockGeneratorPluginReturnThruPtr, "Verify CMockGeneratorPluginReturnTh
       " Pine_CMockReturnMemThruPtr_tofu(__LINE__, tofu, cmock_len * sizeof(*tofu))\n" +
       "#define Pine_ReturnMemThruPtr_tofu(tofu, cmock_size)" +
       " Pine_CMockReturnMemThruPtr_tofu(__LINE__, tofu, cmock_size)\n" +
-      "void Pine_CMockReturnMemThruPtr_tofu(UNITY_LINE_TYPE cmock_line, int* tofu, size_t cmock_size);\n"
+      "void Pine_CMockReturnMemThruPtr_tofu(UNITY_LINE_TYPE cmock_line, int const* tofu, size_t cmock_size);\n"+
+      "#define Pine_ReturnThruPtr_bean_buffer(bean_buffer)" +
+      " Pine_CMockReturnMemThruPtr_bean_buffer(__LINE__, bean_buffer, sizeof(char*))\n" +
+      "#define Pine_ReturnArrayThruPtr_bean_buffer(bean_buffe, cmock_len)" +
+      " Pine_CMockReturnMemThruPtr_bean_buffer(__LINE__, bean_buffer, cmock_len * sizeof(*bean_buffer))\n" +
+      "#define Pine_ReturnMemThruPtr_bean_buffer(bean_buffe, cmock_size)" +
+      " Pine_CMockReturnMemThruPtr_bean_buffer(__LINE__, bean_buffer, cmock_size)\n" +
+      "void Pine_CMockReturnMemThruPtr_bean_buffer(UNITY_LINE_TYPE cmock_line, char* const* bean_buffer, size_t cmock_size);\n"
 
     returned = @cmock_generator_plugin_return_thru_ptr.mock_function_declarations(@complex_func)
     assert_equal(expected, returned)
@@ -104,7 +119,7 @@ describe CMockGeneratorPluginReturnThruPtr, "Verify CMockGeneratorPluginReturnTh
     complex_func_expect();
 
     expected =
-      "void Pine_CMockReturnMemThruPtr_tofu(UNITY_LINE_TYPE cmock_line, int* tofu, size_t cmock_size)\n" +
+      "void Pine_CMockReturnMemThruPtr_tofu(UNITY_LINE_TYPE cmock_line, int const* tofu, size_t cmock_size)\n" +
       "{\n" +
       "  CMOCK_Pine_CALL_INSTANCE* cmock_call_instance = " +
       "(CMOCK_Pine_CALL_INSTANCE*)CMock_Guts_GetAddressFor(CMock_Guts_MemEndOfChain(Mock.Pine_CallInstance));\n" +
@@ -112,6 +127,15 @@ describe CMockGeneratorPluginReturnThruPtr, "Verify CMockGeneratorPluginReturnTh
       "  cmock_call_instance->ReturnThruPtr_tofu_Used = 1;\n" +
       "  cmock_call_instance->ReturnThruPtr_tofu_Val = tofu;\n" +
       "  cmock_call_instance->ReturnThruPtr_tofu_Size = cmock_size;\n" +
+      "}\n\n" +
+      "void Pine_CMockReturnMemThruPtr_bean_buffer(UNITY_LINE_TYPE cmock_line, char* const* bean_buffer, size_t cmock_size)\n" +
+      "{\n" +
+      "  CMOCK_Pine_CALL_INSTANCE* cmock_call_instance = " +
+      "(CMOCK_Pine_CALL_INSTANCE*)CMock_Guts_GetAddressFor(CMock_Guts_MemEndOfChain(Mock.Pine_CallInstance));\n" +
+      "  UNITY_TEST_ASSERT_NOT_NULL(cmock_call_instance, cmock_line, CMockStringPtrPreExp);\n" +
+      "  cmock_call_instance->ReturnThruPtr_bean_buffer_Used = 1;\n" +
+      "  cmock_call_instance->ReturnThruPtr_bean_buffer_Val = bean_buffer;\n" +
+      "  cmock_call_instance->ReturnThruPtr_bean_buffer_Size = cmock_size;\n" +
       "}\n\n"
 
     returned = @cmock_generator_plugin_return_thru_ptr.mock_interfaces(@complex_func).join("")
@@ -125,8 +149,14 @@ describe CMockGeneratorPluginReturnThruPtr, "Verify CMockGeneratorPluginReturnTh
       "  if (cmock_call_instance->ReturnThruPtr_tofu_Used)\n" +
       "  {\n" +
       "    UNITY_TEST_ASSERT_NOT_NULL(tofu, cmock_line, CMockStringPtrIsNULL);\n" +
-      "    memcpy((void*)tofu, (void*)cmock_call_instance->ReturnThruPtr_tofu_Val,\n" +
+      "    memcpy((void*)tofu, (const void*)cmock_call_instance->ReturnThruPtr_tofu_Val,\n" +
       "      cmock_call_instance->ReturnThruPtr_tofu_Size);\n" +
+      "  }\n" +
+      "  if (cmock_call_instance->ReturnThruPtr_bean_buffer_Used)\n" +
+      "  {\n" +
+      "    UNITY_TEST_ASSERT_NOT_NULL(bean_buffer, cmock_line, CMockStringPtrIsNULL);\n" +
+      "    memcpy((void*)bean_buffer, (const void*)cmock_call_instance->ReturnThruPtr_bean_buffer_Val,\n" +
+      "      cmock_call_instance->ReturnThruPtr_bean_buffer_Size);\n" +
       "  }\n"
 
     returned = @cmock_generator_plugin_return_thru_ptr.mock_implementation(@complex_func).join("")

--- a/test/unit/cmock_generator_plugin_return_thru_ptr_test.rb
+++ b/test/unit/cmock_generator_plugin_return_thru_ptr_test.rb
@@ -105,9 +105,9 @@ describe CMockGeneratorPluginReturnThruPtr, "Verify CMockGeneratorPluginReturnTh
       "void Pine_CMockReturnMemThruPtr_tofu(UNITY_LINE_TYPE cmock_line, int const* tofu, size_t cmock_size);\n"+
       "#define Pine_ReturnThruPtr_bean_buffer(bean_buffer)" +
       " Pine_CMockReturnMemThruPtr_bean_buffer(__LINE__, bean_buffer, sizeof(char*))\n" +
-      "#define Pine_ReturnArrayThruPtr_bean_buffer(bean_buffe, cmock_len)" +
+      "#define Pine_ReturnArrayThruPtr_bean_buffer(bean_buffer, cmock_len)" +
       " Pine_CMockReturnMemThruPtr_bean_buffer(__LINE__, bean_buffer, cmock_len * sizeof(*bean_buffer))\n" +
-      "#define Pine_ReturnMemThruPtr_bean_buffer(bean_buffe, cmock_size)" +
+      "#define Pine_ReturnMemThruPtr_bean_buffer(bean_buffer, cmock_size)" +
       " Pine_CMockReturnMemThruPtr_bean_buffer(__LINE__, bean_buffer, cmock_size)\n" +
       "void Pine_CMockReturnMemThruPtr_bean_buffer(UNITY_LINE_TYPE cmock_line, char* const* bean_buffer, size_t cmock_size);\n"
 


### PR DESCRIPTION
Previously, using ReturnMemThruPtr with data defined as `const` may result in linters warning about discarding const. As the data is just copied by the mock, making the parameter and struct member a pointer-to-const is valid.

This partly addresses #259.