### PR TITLE
add check to prevent sizeof(void) generation

### DIFF
--- a/test/unit/cmock_generator_plugin_return_thru_ptr_test.rb
+++ b/test/unit/cmock_generator_plugin_return_thru_ptr_test.rb
@@ -39,6 +39,18 @@ describe CMockGeneratorPluginReturnThruPtr, "Verify CMockGeneratorPluginReturnTh
                      :return => test_return[:void],
                      :contains_ptr? => true }
 
+    @void_ptr_func = {:name => "Spruce",
+                      :args => [{ :type => "void*",
+                                :name => "pork",
+                                :ptr? => true,
+                              },
+                              { :type => "MY_FANCY_VOID*",
+                                :name => "salad",
+                                :ptr? => true,
+                              }],
+                      :return => test_return[:void],
+                      :contains_ptr? => true }
+
     #no strict ordering
     @cmock_generator_plugin_return_thru_ptr = CMockGeneratorPluginReturnThruPtr.new(@config, @utils)
   end
@@ -54,6 +66,13 @@ describe CMockGeneratorPluginReturnThruPtr, "Verify CMockGeneratorPluginReturnTh
     @utils.expect :ptr_or_str?, false, ['int']
     @utils.expect :ptr_or_str?, true, ['const int*']
     @utils.expect :ptr_or_str?, true, ['int*']
+  end
+
+  def void_ptr_func_expect
+    @utils.expect :ptr_or_str?, true, ['void*']
+    @utils.expect :ptr_or_str?, true, ['MY_FANCY_VOID*']
+
+    @config.expect :treat_as_void, ['MY_FANCY_VOID']
   end
 
   it "have set up internal priority correctly on init" do
@@ -97,6 +116,29 @@ describe CMockGeneratorPluginReturnThruPtr, "Verify CMockGeneratorPluginReturnTh
       "void Pine_CMockReturnMemThruPtr_tofu(UNITY_LINE_TYPE cmock_line, int* tofu, size_t cmock_size);\n"
 
     returned = @cmock_generator_plugin_return_thru_ptr.mock_function_declarations(@complex_func)
+    assert_equal(expected, returned)
+  end
+
+  it "add a mock function declaration with sizeof(<name>) for void pointer arguments" do
+    void_ptr_func_expect();
+
+    expected =
+    "#define Spruce_ReturnThruPtr_pork(pork)" +
+    " Spruce_CMockReturnMemThruPtr_pork(__LINE__, pork, sizeof(*pork))\n" +
+    "#define Spruce_ReturnArrayThruPtr_pork(pork, cmock_len)" +
+    " Spruce_CMockReturnMemThruPtr_pork(__LINE__, pork, cmock_len * sizeof(*pork))\n" +
+    "#define Spruce_ReturnMemThruPtr_pork(pork, cmock_size)" +
+    " Spruce_CMockReturnMemThruPtr_pork(__LINE__, pork, cmock_size)\n" +
+    "void Spruce_CMockReturnMemThruPtr_pork(UNITY_LINE_TYPE cmock_line, void* pork, size_t cmock_size);\n" + 
+    "#define Spruce_ReturnThruPtr_salad(salad)" +
+    " Spruce_CMockReturnMemThruPtr_salad(__LINE__, salad, sizeof(*salad))\n" +
+    "#define Spruce_ReturnArrayThruPtr_salad(salad, cmock_len)" +
+    " Spruce_CMockReturnMemThruPtr_salad(__LINE__, salad, cmock_len * sizeof(*salad))\n" +
+    "#define Spruce_ReturnMemThruPtr_salad(salad, cmock_size)" +
+    " Spruce_CMockReturnMemThruPtr_salad(__LINE__, salad, cmock_size)\n" +
+    "void Spruce_CMockReturnMemThruPtr_salad(UNITY_LINE_TYPE cmock_line, MY_FANCY_VOID* salad, size_t cmock_size);\n"
+
+    returned = @cmock_generator_plugin_return_thru_ptr.mock_function_declarations(@void_ptr_func)
     assert_equal(expected, returned)
   end
 


### PR DESCRIPTION
Mock generation by the Return_Thru_Ptr plugin can result in a `sizeof(void)` expression to be generated if a mocked function contains a `void*`-argument.

A previous implementation (some versions ago) generated the resulting mock with a `sizeof(*<parameter name>)`, the current implementation uses `sizeof(<typename without ptr>)` if the parameter is a pointer.

This pull request adds a check to verify that the argument type is not a pointer to void, if it is then `sizeof(*<parameter name>)` will be generated. For me this fixes the issue.

Im no professional ruby developer so im always happy for feedback :)

Relevant issue: https://github.com/ThrowTheSwitch/Ceedling/issues/795