### PR TITLE
Fixed newline being added to the skeleton file everytime the skeleton generator is invoked.

### DIFF
--- a/lib/cmock_generator.rb
+++ b/lib/cmock_generator.rb
@@ -140,7 +140,10 @@ class CMockGenerator
       if existing.empty?
         create_source_header_section(file, fullname, blank_project)
       else
-        file << existing << "\n"
+        file << existing
+        if existing[-1] != "\n"
+          file << "\n"
+        end
       end
       mock_project[:parsed_stuff][:functions].each do |function|
         create_function_skeleton(file, function, existing)


### PR DESCRIPTION
Every time the skeleton mock generator script `cmock.rb` is being called with the `--skeleton` option and a header file, a newline is being added at the end of the generated skeleton file.  
I invoke the skeleton generator script every time I run unity tests, which results in lots of added newlines in the skeleton file.
This change adds a check whether the last character of the skeleton file is already a newline, and only adds the newline if it isn't already there.