### PR TITLE
Unset argument detail before calling callback

### DIFF
--- a/lib/cmock_generator_plugin_callback.rb
+++ b/lib/cmock_generator_plugin_callback.rb
@@ -43,7 +43,8 @@ class CMockGeneratorPluginCallback
   end
 
   def mock_implementation(function)
-    "  if (Mock.#{function[:name]}_CallbackFunctionPointer != NULL)\n  {\n" +
+    "  if (Mock.#{function[:name]}_CallbackFunctionPointer != NULL)\n  {\n" \
+    "    UNITY_SET_DETAIL(CMockString_#{function[:name]});\n" +
       if function[:return][:void?]
         "    #{generate_call(function)};\n  }\n"
       else

--- a/test/unit/cmock_generator_plugin_callback_test.rb
+++ b/test/unit/cmock_generator_plugin_callback_test.rb
@@ -96,6 +96,7 @@ describe CMockGeneratorPluginCallback, "Verify CMockGeneratorPluginCallback Modu
     function = {:name => "Apple", :args => [], :args_string => "void", :return => test_return[:void]}
     expected = ["  if (Mock.Apple_CallbackFunctionPointer != NULL)\n",
                 "  {\n",
+                "    UNITY_SET_DETAIL(CMockString_#{function[:name]});\n",
                 "    Mock.Apple_CallbackFunctionPointer(Mock.Apple_CallbackCalls++);\n",
                 "  }\n"
                ].join
@@ -107,6 +108,7 @@ describe CMockGeneratorPluginCallback, "Verify CMockGeneratorPluginCallback Modu
     function = {:name => "Apple", :args => [], :args_string => "void", :return => test_return[:void]}
     expected = ["  if (Mock.Apple_CallbackFunctionPointer != NULL)\n",
                 "  {\n",
+                "    UNITY_SET_DETAIL(CMockString_#{function[:name]});\n",
                 "    Mock.Apple_CallbackFunctionPointer();\n",
                 "  }\n"
                ].join
@@ -119,6 +121,7 @@ describe CMockGeneratorPluginCallback, "Verify CMockGeneratorPluginCallback Modu
     function = {:name => "Apple", :args => [], :args_string => "void", :return => test_return[:int]}
     expected = ["  if (Mock.Apple_CallbackFunctionPointer != NULL)\n",
                 "  {\n",
+                "    UNITY_SET_DETAIL(CMockString_#{function[:name]});\n",
                 "    cmock_call_instance->ReturnVal = Mock.Apple_CallbackFunctionPointer(Mock.Apple_CallbackCalls++);\n",
                 "  }\n"
                ].join
@@ -134,6 +137,7 @@ describe CMockGeneratorPluginCallback, "Verify CMockGeneratorPluginCallback Modu
                 :return=> test_return[:void]}
     expected = ["  if (Mock.Apple_CallbackFunctionPointer != NULL)\n",
                 "  {\n",
+                "    UNITY_SET_DETAIL(CMockString_#{function[:name]});\n",
                 "    Mock.Apple_CallbackFunctionPointer(steak, flag, Mock.Apple_CallbackCalls++);\n",
                 "  }\n"
                ].join
@@ -149,6 +153,7 @@ describe CMockGeneratorPluginCallback, "Verify CMockGeneratorPluginCallback Modu
                 :return=> test_return[:void]}
     expected = ["  if (Mock.Apple_CallbackFunctionPointer != NULL)\n",
                 "  {\n",
+                "    UNITY_SET_DETAIL(CMockString_#{function[:name]});\n",
                 "    Mock.Apple_CallbackFunctionPointer(steak, flag);\n",
                 "  }\n"
                ].join
@@ -165,6 +170,7 @@ describe CMockGeneratorPluginCallback, "Verify CMockGeneratorPluginCallback Modu
                 :return => test_return[:int]}
     expected = ["  if (Mock.Apple_CallbackFunctionPointer != NULL)\n",
                 "  {\n",
+                "    UNITY_SET_DETAIL(CMockString_#{function[:name]});\n",
                 "    cmock_call_instance->ReturnVal = Mock.Apple_CallbackFunctionPointer(steak, flag, Mock.Apple_CallbackCalls++);\n",
                 "  }\n"
                ].join


### PR DESCRIPTION
🍍

As the callback is called after validating the last argument, but before CLR_DETAILS, the detail is still set to function+last argument, leading to confusing output.

This changes it so the argument name is cleared before calling the callback.

For stubs, no change is needed, as those are called before the arguments, so just the function name is already set at that point.