### PR TITLE
:seedling: Runner generation with optional configuration

### DIFF
--- a/scripts/create_runner.rb
+++ b/scripts/create_runner.rb
@@ -8,18 +8,26 @@
 if $0 == __FILE__
 
   # make sure there is at least one parameter left (the input file)
-  if ARGV.length < 2
-    puts ["\nusage: ruby #{__FILE__} input_test_file (output)",
+  if ARGV.empty?
+    puts ["\nusage: ruby #{__FILE__} input_test_file [output_runner] [config.yml]",
           '',
           '  input_test_file         - this is the C file you want to create a runner for',
-          '  output                  - this is the name of the runner file to generate',
-          '                            defaults to (input_test_file)_Runner'].join("\n")
+          '  output_runner           - (optional) the name of the runner file to generate',
+          '                            defaults to (input_test_file)_Runner.c',
+          '  config.yml              - (optional) a yaml file with configuration.'].join("\n")
     exit 1
   end
 
   require "#{ENV['UNITY_DIR']}/auto/generate_test_runner"
 
-  test = ARGV[0]
-  runner = ARGV[1]
-  UnityTestRunnerGenerator.new.run(test, runner)
+  test_file = ARGV[0]
+  runner_file = ARGV[1] || test_file.sub(/\.c$/, '_Runner.c')
+  config_file = ARGV[2]
+
+  # if a config file is provided and exists, use it.
+  if config_file && File.exist?(config_file)
+    UnityTestRunnerGenerator.new(config_file).run(test_file, runner_file)
+  else
+    UnityTestRunnerGenerator.new.run(test_file, runner_file)
+  end
 end


### PR DESCRIPTION
:pineapple: Allows for the Unity Test Runner to be generated by optionally 
providing a configuration file specified as a command line argument.

This change is meant to allow unit test make scripts of custom projects 
that utilize CMock generator to be able to conveniently enable optional 
Unity features like, e.g., parameterized tests, when this framework 
is integrated and managed by the custom project as a Git submodule 
external dependency. That way local changes in configuration to 
the third-party sources/scripts are avoided.
