### PR TITLE
Only update mock files when there is a difference between src and dest

### DIFF
--- a/lib/cmock_file_writer.rb
+++ b/lib/cmock_file_writer.rb
@@ -42,7 +42,13 @@ class CMockFileWriter
 
   def update_file(dest, src)
     require 'fileutils'
-    FileUtils.rm(dest, :force => true)
-    FileUtils.mv(src, dest)
+
+    # Only write files if the contents differ, may prevent unnecessary compilation
+    if File.exist?(dest) && File.binread(dest) == File.binread(src)
+        FileUtils.rm(src, :force => true)
+    else
+        FileUtils.rm(dest, :force => true)
+        FileUtils.mv(src, dest)
+    end
   end
 end


### PR DESCRIPTION
The proposed patch compares the generated mock files, and only performs a swap when the content is different.

The intent it to reduce the likelihood that downstream compilation is triggered by the fact the timestamps will change despite the content being identical.

I am not a Ruby expert, so please do scrutinise if the proposed solution is not quite right