### PR TITLE
[typo] Fix misspelling in temperature test name

### DIFF
--- a/examples/temp_sensor/test/TestTemperatureFilter.c
+++ b/examples/temp_sensor/test/TestTemperatureFilter.c
@@ -19,7 +19,7 @@ void tearDown(void)
 {
 }
 
-void testShouldInitializeTemeratureToInvalidValue(void)
+void testShouldInitializeTemperatureToInvalidValue(void)
 {
   TemperatureFilter_Init();
   TEST_ASSERT_FLOAT_WITHIN(0.0001f, -INFINITY, TemperatureFilter_GetTemperatureInCelcius());


### PR DESCRIPTION
🍍 
Rename testShouldInitializeTemeratureToInvalidValue to 
testShouldInitializeTemperatureToInvalidValue.