### PR TITLE
Meson: bump required version to 0.54

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,7 @@
 #
 project('cmock', 'c',
     license: 'MIT',
-    meson_version: '>=0.53.0',
+    meson_version: '>=0.54.0',
     subproject_dir : 'vendor',
     default_options: ['werror=true', 'c_std=c11']
 )


### PR DESCRIPTION
Fixed the following warning:

```
cmock| subprojects/CMock-2.7.0/meson.build:14: WARNING: Project targets '>= 0.53.0' but uses feature introduced in '0.54.0': fallback arg in dependency.
```

Closes https://github.com/ThrowTheSwitch/CMock/issues/538

Would be great if a 2.7.1 with this could be tagged since it currently blocks https://github.com/mesonbuild/wrapdb/pull/2846.